### PR TITLE
feat(web): 履歴書・職務経歴書の認証付きダウンロード機能

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,3 +34,24 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Resume download environment variables
+
+Create the Vercel Blob store with private access. Configure the following server-only environment variables in each deployment environment. Do not add them to `next.config.mjs` or commit the resume files to this repository.
+
+- `RESUME_PASSWORD`: Password for the `/resume` download form
+- `RESUME_ADMIN_PASSWORD`: Password for `/admin/resume`
+- `RESUME_SIGNING_SECRET`: Secret used to sign download URLs and admin sessions
+
+### Uploading the resume files
+
+Vercel ダッシュボード → Storage → Blob で private access のストアを作成し、次の pathname へ4ファイルをアップロードする。
+
+- `resume/rirekisho.pdf`
+- `resume/rirekisho.xlsx`
+- `resume/shokumu-keirekisho.pdf`
+- `resume/shokumu-keirekisho.xlsx`
+
+`RESUME_SIGNING_SECRET` は `openssl rand -base64 32` などで十分に長いランダム値を生成する。
+
+Blob への認証は `@vercel/blob` SDK が環境変数から自動解決する。private ストアをプロジェクトへ接続すると、Vercel 上では認証情報が自動注入される。ローカル開発では `VERCEL_OIDC_TOKEN` と `BLOB_STORE_ID` をルートの `.env.local` に設定する（`pnpm dev` が `dotenv -e .env.local` で読み込む）。OIDC トークンは短命なので、期限切れになったら再取得すること。

--- a/apps/web/actions/resume/adminLogin/index.ts
+++ b/apps/web/actions/resume/adminLogin/index.ts
@@ -1,0 +1,36 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import type { z } from 'zod'
+
+import { schema } from '~/actions/resume/adminLogin/schema'
+import { createSafeAction } from '~/lib/create-safe-action'
+import { ADMIN_SESSION_COOKIE_NAME } from '~/lib/resume/admin-session'
+import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { verifyPassword } from '~/lib/resume/password'
+import { createAdminSessionToken } from '~/lib/resume/token'
+
+export async function handler(input: z.infer<typeof schema>) {
+  const expectedPassword = getRequiredResumeEnv('RESUME_ADMIN_PASSWORD')
+
+  if (!verifyPassword(input.password, expectedPassword)) {
+    return { error: 'パスワードが違います' }
+  }
+
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
+  const token = createAdminSessionToken(expiresAt, secret)
+  const cookieStore = await cookies()
+
+  cookieStore.set(ADMIN_SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/admin/resume',
+    expires: expiresAt,
+  })
+
+  return { data: { success: true } }
+}
+
+export const adminLogin = createSafeAction('adminLogin', schema, handler)

--- a/apps/web/actions/resume/adminLogin/schema.ts
+++ b/apps/web/actions/resume/adminLogin/schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const schema = z.object({
+  password: z.string().min(1),
+})

--- a/apps/web/actions/resume/issueDownloadUrl/index.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/index.ts
@@ -1,0 +1,59 @@
+'use server'
+
+import { headers } from 'next/headers'
+import type { z } from 'zod'
+
+import { schema } from '~/actions/resume/issueDownloadUrl/schema'
+import { createSafeAction } from '~/lib/create-safe-action'
+import { hasValidAdminSession } from '~/lib/resume/admin-session'
+import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { createResumeToken } from '~/lib/resume/token'
+
+function getRequestOrigin(headerStore: Headers) {
+  const host = headerStore.get('host')
+  const forwardedProto = headerStore
+    .get('x-forwarded-proto')
+    ?.split(',')[0]
+    ?.trim()
+  const protocol = forwardedProto === 'http' ? 'http' : 'https'
+
+  if (!host) {
+    throw new Error('Resume URL issue error: host header is not set')
+  }
+
+  return `${protocol}://${host}`
+}
+
+export async function handler(input: z.infer<typeof schema>) {
+  const now = new Date()
+
+  if (!(await hasValidAdminSession(now))) {
+    return { error: '認証が必要です' }
+  }
+
+  const expiresAt = new Date(
+    now.getTime() + Number(input.expiresInDays) * 24 * 60 * 60 * 1000
+  )
+  const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
+  const token = createResumeToken({ id: input.id, expiresAt }, secret)
+  const searchParams = new URLSearchParams({
+    id: token.id,
+    exp: String(token.exp),
+    sig: token.sig,
+  })
+  const headerStore = await headers()
+  const origin = getRequestOrigin(headerStore)
+
+  return {
+    data: {
+      url: `${origin}/api/resume/download?${searchParams}`,
+      expiresAt: expiresAt.toISOString(),
+    },
+  }
+}
+
+export const issueDownloadUrl = createSafeAction(
+  'issueDownloadUrl',
+  schema,
+  handler
+)

--- a/apps/web/actions/resume/issueDownloadUrl/schema.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const schema = z.object({
+  id: z.enum([
+    'rirekisho-pdf',
+    'rirekisho-xlsx',
+    'shokumu-keirekisho-pdf',
+    'shokumu-keirekisho-xlsx',
+  ]),
+  expiresInDays: z.enum(['1', '7', '30']),
+})

--- a/apps/web/actions/resume/requestDownloadUrl/index.ts
+++ b/apps/web/actions/resume/requestDownloadUrl/index.ts
@@ -1,0 +1,34 @@
+'use server'
+
+import type { z } from 'zod'
+
+import { schema } from '~/actions/resume/requestDownloadUrl/schema'
+import { createSafeAction } from '~/lib/create-safe-action'
+import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { verifyPassword } from '~/lib/resume/password'
+import { createResumeToken } from '~/lib/resume/token'
+
+export async function handler(input: z.infer<typeof schema>) {
+  const expectedPassword = getRequiredResumeEnv('RESUME_PASSWORD')
+
+  if (!verifyPassword(input.password, expectedPassword)) {
+    return { error: 'パスワードが違います' }
+  }
+
+  const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
+  const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
+  const token = createResumeToken({ id: input.id, expiresAt }, secret)
+  const searchParams = new URLSearchParams({
+    id: token.id,
+    exp: String(token.exp),
+    sig: token.sig,
+  })
+
+  return { data: { url: `/api/resume/download?${searchParams}` } }
+}
+
+export const requestDownloadUrl = createSafeAction(
+  'requestDownloadUrl',
+  schema,
+  handler
+)

--- a/apps/web/actions/resume/requestDownloadUrl/schema.ts
+++ b/apps/web/actions/resume/requestDownloadUrl/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const schema = z.object({
+  password: z.string().min(1),
+  id: z.enum([
+    'rirekisho-pdf',
+    'rirekisho-xlsx',
+    'shokumu-keirekisho-pdf',
+    'shokumu-keirekisho-xlsx',
+  ]),
+})

--- a/apps/web/app/(children)/resume/page.tsx
+++ b/apps/web/app/(children)/resume/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+import { DownloadForm } from '~/features/Resume/DownloadForm'
+
+export const metadata: Metadata = {
+  title: 'Resume Download',
+  robots: { index: false, follow: false },
+}
+
+export default function ResumePage() {
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-background px-6 py-20 text-foreground">
+      <DownloadForm />
+    </div>
+  )
+}

--- a/apps/web/app/admin/resume/page.tsx
+++ b/apps/web/app/admin/resume/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+
+import { AdminLoginForm, AdminPanel } from '~/features/Resume/AdminPanel'
+import { hasValidAdminSession } from '~/lib/resume/admin-session'
+
+export const metadata: Metadata = {
+  title: 'Resume Admin',
+  robots: { index: false, follow: false },
+}
+
+export default async function AdminResumePage() {
+  const isLoggedIn = await hasValidAdminSession(new Date())
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-6 py-20 text-foreground">
+      {isLoggedIn ? <AdminPanel /> : <AdminLoginForm />}
+    </div>
+  )
+}

--- a/apps/web/app/api/resume/download/route.ts
+++ b/apps/web/app/api/resume/download/route.ts
@@ -1,0 +1,88 @@
+import { get } from '@vercel/blob'
+
+import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { isResumeFileId, verifyResumeToken } from '~/lib/resume/token'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+export const runtime = 'nodejs'
+
+const RESUME_FILES = {
+  'rirekisho-pdf': {
+    pathname: 'resume/rirekisho.pdf',
+    filename: '履歴書.pdf',
+    contentType: 'application/pdf',
+  },
+  'rirekisho-xlsx': {
+    pathname: 'resume/rirekisho.xlsx',
+    filename: '履歴書.xlsx',
+    contentType:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  },
+  'shokumu-keirekisho-pdf': {
+    pathname: 'resume/shokumu-keirekisho.pdf',
+    filename: '職務経歴書.pdf',
+    contentType: 'application/pdf',
+  },
+  'shokumu-keirekisho-xlsx': {
+    pathname: 'resume/shokumu-keirekisho.xlsx',
+    filename: '職務経歴書.xlsx',
+    contentType:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  },
+} satisfies Record<
+  ResumeFileId,
+  { pathname: string; filename: string; contentType: string }
+>
+
+function jsonError(message: string, status: number) {
+  return Response.json({ message }, { status })
+}
+
+export async function GET(request: Request) {
+  const searchParams = new URL(request.url).searchParams
+  const id = searchParams.get('id')
+  const exp = searchParams.get('exp') ?? ''
+  const sig = searchParams.get('sig') ?? ''
+
+  if (!id || !isResumeFileId(id)) {
+    return jsonError('書類の指定が不正です', 400)
+  }
+
+  try {
+    const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
+    const tokenResult = verifyResumeToken({ id, exp, sig }, secret, new Date())
+
+    if (!tokenResult.ok) {
+      return tokenResult.reason === 'expired'
+        ? jsonError('ダウンロードURLの有効期限が切れています', 403)
+        : jsonError('ダウンロードURLが無効です', 403)
+    }
+
+    const resumeFile = RESUME_FILES[tokenResult.id]
+    const blobResult = await get(resumeFile.pathname, {
+      access: 'private',
+    })
+
+    if (blobResult?.statusCode !== 200 || !blobResult?.stream) {
+      return jsonError('ファイルの取得に失敗しました', 502)
+    }
+
+    return new Response(blobResult.stream, {
+      headers: {
+        'Cache-Control': 'no-store',
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(resumeFile.filename)}`,
+        'Content-Type': resumeFile.contentType,
+        'X-Robots-Tag': 'noindex',
+      },
+    })
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith('Resume configuration error:')
+    ) {
+      return jsonError(error.message, 500)
+    }
+
+    return jsonError('ファイルの取得に失敗しました', 502)
+  }
+}

--- a/apps/web/features/Home/HomeWrapper/components/HomeWrapper.tsx
+++ b/apps/web/features/Home/HomeWrapper/components/HomeWrapper.tsx
@@ -112,6 +112,12 @@ function Profile() {
               >
                 ポートフォリオを見る
               </a>
+              <a
+                href="/resume"
+                className="px-8 py-3 rounded-lg border border-slate-200 dark:border-slate-800 font-medium hover:bg-slate-50 dark:hover:bg-slate-900 transition-colors"
+              >
+                経歴書ダウンロード
+              </a>
             </div>
           </div>
         </motion.div>

--- a/apps/web/features/Resume/AdminPanel/components/AdminLoginForm.tsx
+++ b/apps/web/features/Resume/AdminPanel/components/AdminLoginForm.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { Button } from '@repo/ui/components/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@repo/ui/components/card'
+import { Input } from '@repo/ui/components/input'
+import { Label } from '@repo/ui/components/label'
+import { useRouter } from 'next/navigation'
+import { useAction } from 'next-safe-action/hooks'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { adminLogin } from '~/actions/resume/adminLogin'
+
+function getActionError(value: unknown) {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('error' in value) ||
+    typeof value.error !== 'string'
+  ) {
+    return null
+  }
+
+  return value.error
+}
+
+export function AdminLoginForm() {
+  const [password, setPassword] = useState('')
+  const [isPending, setIsPending] = useState(false)
+  const { executeAsync } = useAction(adminLogin)
+  const router = useRouter()
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsPending(true)
+
+    try {
+      const result = await executeAsync({ password })
+      const actionError = getActionError(result?.data)
+
+      if (actionError) {
+        toast.error(actionError)
+        return
+      }
+
+      if (!result?.data?.data?.success) {
+        toast.error('ログインできませんでした')
+        return
+      }
+
+      router.refresh()
+    } catch {
+      toast.error('ログインできませんでした')
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>管理者ログイン</CardTitle>
+        <CardDescription>
+          署名付きダウンロードURLを発行するにはログインしてください。
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="admin-password">管理者パスワード</Label>
+            <Input
+              id="admin-password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="pt-6">
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? 'ログイン中…' : 'ログイン'}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
+++ b/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { Button } from '@repo/ui/components/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@repo/ui/components/card'
+import { Input } from '@repo/ui/components/input'
+import { Label } from '@repo/ui/components/label'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/ui/components/select'
+import { useAction } from 'next-safe-action/hooks'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { issueDownloadUrl } from '~/actions/resume/issueDownloadUrl'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+function getActionError(value: unknown) {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('error' in value) ||
+    typeof value.error !== 'string'
+  ) {
+    return null
+  }
+
+  return value.error
+}
+
+export function AdminPanel() {
+  const [fileId, setFileId] = useState<ResumeFileId>('rirekisho-pdf')
+  const [expiresInDays, setExpiresInDays] = useState<'1' | '7' | '30'>('1')
+  const [issuedUrl, setIssuedUrl] = useState('')
+  const [issuedExpiresAt, setIssuedExpiresAt] = useState('')
+  const [isPending, setIsPending] = useState(false)
+  const { executeAsync } = useAction(issueDownloadUrl)
+
+  async function handleIssue(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsPending(true)
+
+    try {
+      const result = await executeAsync({ id: fileId, expiresInDays })
+      const actionError = getActionError(result?.data)
+
+      if (actionError) {
+        toast.error(actionError)
+        return
+      }
+
+      const issued = result?.data?.data
+
+      if (!issued) {
+        toast.error('URLを発行できませんでした')
+        return
+      }
+
+      setIssuedUrl(issued.url)
+      setIssuedExpiresAt(issued.expiresAt)
+      toast.success('ダウンロードURLを発行しました')
+    } catch {
+      toast.error('URLを発行できませんでした')
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(issuedUrl)
+      toast.success('URLをコピーしました')
+    } catch {
+      toast.error('URLをコピーできませんでした')
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-2xl">
+      <CardHeader>
+        <CardTitle>ダウンロードURL発行</CardTitle>
+        <CardDescription>
+          書類と有効期限を選んで、共有用の署名URLを発行します。
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleIssue}>
+        <CardContent className="flex flex-col gap-5">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="resume-document">書類</Label>
+            <Select
+              value={fileId}
+              onValueChange={(value) => {
+                if (
+                  value === 'rirekisho-pdf' ||
+                  value === 'rirekisho-xlsx' ||
+                  value === 'shokumu-keirekisho-pdf' ||
+                  value === 'shokumu-keirekisho-xlsx'
+                ) {
+                  setFileId(value)
+                }
+              }}
+            >
+              <SelectTrigger id="resume-document" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="rirekisho-pdf">履歴書 PDF</SelectItem>
+                  <SelectItem value="rirekisho-xlsx">履歴書 Excel</SelectItem>
+                  <SelectItem value="shokumu-keirekisho-pdf">
+                    職務経歴書 PDF
+                  </SelectItem>
+                  <SelectItem value="shokumu-keirekisho-xlsx">
+                    職務経歴書 Excel
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="resume-expiration">有効期限</Label>
+            <Select
+              value={expiresInDays}
+              onValueChange={(value) => {
+                if (value === '1' || value === '7' || value === '30') {
+                  setExpiresInDays(value)
+                }
+              }}
+            >
+              <SelectTrigger id="resume-expiration" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="1">24時間</SelectItem>
+                  <SelectItem value="7">7日</SelectItem>
+                  <SelectItem value="30">30日</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {issuedUrl && (
+            <div className="flex flex-col gap-3 rounded-lg border p-4">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="issued-url">発行済みURL</Label>
+                <Input id="issued-url" value={issuedUrl} readOnly />
+              </div>
+              <Button type="button" variant="outline" onClick={handleCopy}>
+                URLをコピー
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                有効期限: {new Date(issuedExpiresAt).toLocaleString('ja-JP')}
+              </p>
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="pt-6">
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? '発行中…' : 'URLを発行'}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/apps/web/features/Resume/AdminPanel/index.ts
+++ b/apps/web/features/Resume/AdminPanel/index.ts
@@ -1,0 +1,2 @@
+export { AdminLoginForm } from '~/features/Resume/AdminPanel/components/AdminLoginForm'
+export { AdminPanel } from '~/features/Resume/AdminPanel/components/AdminPanel'

--- a/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
+++ b/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { Button } from '@repo/ui/components/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@repo/ui/components/card'
+import { Input } from '@repo/ui/components/input'
+import { Label } from '@repo/ui/components/label'
+import { useAction } from 'next-safe-action/hooks'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { requestDownloadUrl } from '~/actions/resume/requestDownloadUrl'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+function getActionError(value: unknown) {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('error' in value) ||
+    typeof value.error !== 'string'
+  ) {
+    return null
+  }
+
+  return value.error
+}
+
+export function DownloadForm() {
+  const [password, setPassword] = useState('')
+  const [pendingFileId, setPendingFileId] = useState<ResumeFileId | null>(null)
+  const { executeAsync } = useAction(requestDownloadUrl)
+
+  async function handleDownload(id: ResumeFileId) {
+    if (!password) {
+      toast.error('パスワードを入力してください')
+      return
+    }
+
+    setPendingFileId(id)
+
+    try {
+      const result = await executeAsync({ password, id })
+      const actionError = getActionError(result?.data)
+
+      if (actionError) {
+        toast.error(actionError)
+        return
+      }
+
+      const url = result?.data?.data?.url
+
+      if (!url) {
+        toast.error('ダウンロードURLを発行できませんでした')
+        return
+      }
+
+      window.location.assign(url)
+    } catch {
+      toast.error('ダウンロードURLを発行できませんでした')
+    } finally {
+      setPendingFileId(null)
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-xl">
+      <CardHeader>
+        <CardTitle>経歴書ダウンロード</CardTitle>
+        <CardDescription>
+          共有されたパスワードを入力し、必要な書類を選んでください。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="resume-password">パスワード</Label>
+          <Input
+            id="resume-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col items-stretch gap-3">
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2">
+          <p className="font-medium">履歴書</p>
+          <Button
+            type="button"
+            className="min-w-20"
+            disabled={pendingFileId !== null}
+            onClick={() => handleDownload('rirekisho-pdf')}
+          >
+            {pendingFileId === 'rirekisho-pdf' ? '準備中…' : 'PDF'}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-20"
+            disabled={pendingFileId !== null}
+            onClick={() => handleDownload('rirekisho-xlsx')}
+          >
+            {pendingFileId === 'rirekisho-xlsx' ? '準備中…' : 'Excel'}
+          </Button>
+        </div>
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2">
+          <p className="font-medium">職務経歴書</p>
+          <Button
+            type="button"
+            className="min-w-20"
+            disabled={pendingFileId !== null}
+            onClick={() => handleDownload('shokumu-keirekisho-pdf')}
+          >
+            {pendingFileId === 'shokumu-keirekisho-pdf' ? '準備中…' : 'PDF'}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-20"
+            disabled={pendingFileId !== null}
+            onClick={() => handleDownload('shokumu-keirekisho-xlsx')}
+          >
+            {pendingFileId === 'shokumu-keirekisho-xlsx' ? '準備中…' : 'Excel'}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/features/Resume/DownloadForm/index.ts
+++ b/apps/web/features/Resume/DownloadForm/index.ts
@@ -1,0 +1,1 @@
+export { DownloadForm } from '~/features/Resume/DownloadForm/components/DownloadForm'

--- a/apps/web/lib/resume/admin-session.ts
+++ b/apps/web/lib/resume/admin-session.ts
@@ -1,0 +1,14 @@
+import { cookies } from 'next/headers'
+
+import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { verifyAdminSessionToken } from '~/lib/resume/token'
+
+export const ADMIN_SESSION_COOKIE_NAME = 'resume_admin_session'
+
+export async function hasValidAdminSession(now: Date) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get(ADMIN_SESSION_COOKIE_NAME)?.value
+  const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
+
+  return verifyAdminSessionToken(token, secret, now)
+}

--- a/apps/web/lib/resume/env.ts
+++ b/apps/web/lib/resume/env.ts
@@ -1,0 +1,14 @@
+type ResumeEnvName =
+  | 'RESUME_PASSWORD'
+  | 'RESUME_ADMIN_PASSWORD'
+  | 'RESUME_SIGNING_SECRET'
+
+export function getRequiredResumeEnv(name: ResumeEnvName) {
+  const value = process.env[name]
+
+  if (!value) {
+    throw new Error(`Resume configuration error: ${name} is not set`)
+  }
+
+  return value
+}

--- a/apps/web/lib/resume/password.test.ts
+++ b/apps/web/lib/resume/password.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { verifyPassword } from '~/lib/resume/password'
+
+describe('verifyPassword', () => {
+  it('accepts the matching password', () => {
+    expect(verifyPassword('portfolio-secret', 'portfolio-secret')).toBe(true)
+  })
+
+  it('rejects a different password', () => {
+    expect(verifyPassword('portfolio-secret', 'different-secret')).toBe(false)
+  })
+
+  it('rejects a password with a different length', () => {
+    expect(verifyPassword('short', 'a-much-longer-password')).toBe(false)
+  })
+})

--- a/apps/web/lib/resume/password.ts
+++ b/apps/web/lib/resume/password.ts
@@ -1,0 +1,8 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+export function verifyPassword(input: string, expected: string) {
+  const inputHash = createHash('sha256').update(input).digest()
+  const expectedHash = createHash('sha256').update(expected).digest()
+
+  return timingSafeEqual(inputHash, expectedHash)
+}

--- a/apps/web/lib/resume/token.test.ts
+++ b/apps/web/lib/resume/token.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { createResumeToken, verifyResumeToken } from '~/lib/resume/token'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+const SECRET = 'test-signing-secret'
+const CREATED_AT = new Date('2026-07-13T00:00:00.000Z')
+const EXPIRES_AT = new Date('2026-07-13T00:05:00.000Z')
+const FILE_IDS: ResumeFileId[] = [
+  'rirekisho-pdf',
+  'rirekisho-xlsx',
+  'shokumu-keirekisho-pdf',
+  'shokumu-keirekisho-xlsx',
+]
+
+describe('resume token', () => {
+  it.each(
+    FILE_IDS
+  )('creates a token that verifies with the same file: %s', (id) => {
+    const token = createResumeToken({ id, expiresAt: EXPIRES_AT }, SECRET)
+
+    expect(
+      verifyResumeToken(
+        {
+          id: token.id,
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: true, id })
+  })
+
+  it('rejects an expired token', () => {
+    const token = createResumeToken(
+      { id: 'rirekisho-pdf', expiresAt: EXPIRES_AT },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          id: token.id,
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        new Date('2026-07-13T00:05:01.000Z')
+      )
+    ).toEqual({ ok: false, reason: 'expired' })
+  })
+
+  it.each([
+    {
+      name: 'signature',
+      id: 'rirekisho-pdf',
+      signature: 'tampered',
+      secret: SECRET,
+    },
+    {
+      name: 'file',
+      id: 'shokumu-keirekisho-pdf',
+      signature: undefined,
+      secret: SECRET,
+    },
+    {
+      name: 'secret',
+      id: 'rirekisho-pdf',
+      signature: undefined,
+      secret: 'different-secret',
+    },
+  ])('rejects a token with a tampered $name', ({ id, signature, secret }) => {
+    const token = createResumeToken(
+      {
+        id: 'rirekisho-pdf',
+        expiresAt: EXPIRES_AT,
+      },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          id,
+          exp: String(token.exp),
+          sig: signature ?? token.sig,
+        },
+        secret,
+        CREATED_AT
+      )
+    ).toEqual({ ok: false, reason: 'invalid' })
+  })
+})

--- a/apps/web/lib/resume/token.ts
+++ b/apps/web/lib/resume/token.ts
@@ -1,0 +1,108 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
+
+import type {
+  ResumeFileId,
+  ResumeToken,
+  VerifyResult,
+} from '~/lib/resume/token.types'
+
+function createSignature(message: string, secret: string) {
+  return createHmac('sha256', secret).update(message).digest('base64url')
+}
+
+function signaturesMatch(actual: string, expected: string) {
+  const actualBuffer = createHash('sha256').update(actual).digest()
+  const expectedBuffer = createHash('sha256').update(expected).digest()
+
+  return timingSafeEqual(actualBuffer, expectedBuffer)
+}
+
+export function isResumeFileId(value: string): value is ResumeFileId {
+  return (
+    value === 'rirekisho-pdf' ||
+    value === 'rirekisho-xlsx' ||
+    value === 'shokumu-keirekisho-pdf' ||
+    value === 'shokumu-keirekisho-xlsx'
+  )
+}
+
+export function createResumeToken(
+  input: { id: ResumeFileId; expiresAt: Date },
+  secret: string
+): ResumeToken {
+  const exp = Math.floor(input.expiresAt.getTime() / 1000)
+  const sig = createSignature(`${input.id}:${exp}`, secret)
+
+  return { id: input.id, exp, sig }
+}
+
+export function verifyResumeToken(
+  token: { id: string; exp: string; sig: string },
+  secret: string,
+  now: Date
+): VerifyResult {
+  if (!isResumeFileId(token.id) || !/^\d+$/.test(token.exp)) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  const exp = Number(token.exp)
+
+  if (!Number.isSafeInteger(exp)) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  const expected = createSignature(`${token.id}:${token.exp}`, secret)
+
+  if (!signaturesMatch(token.sig, expected)) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  if (Math.floor(now.getTime() / 1000) > exp) {
+    return { ok: false, reason: 'expired' }
+  }
+
+  return { ok: true, id: token.id }
+}
+
+export function createAdminSessionToken(expiresAt: Date, secret: string) {
+  const exp = Math.floor(expiresAt.getTime() / 1000)
+  const message = `admin:${exp}`
+  const sig = createSignature(message, secret)
+
+  return `${message}:${sig}`
+}
+
+export function verifyAdminSessionToken(
+  token: string | undefined,
+  secret: string,
+  now: Date
+) {
+  if (!token) {
+    return false
+  }
+
+  const parts = token.split(':')
+
+  if (parts.length !== 3) {
+    return false
+  }
+
+  const [scope, exp, sig] = parts
+
+  if (scope !== 'admin' || !exp || !sig || !/^\d+$/.test(exp)) {
+    return false
+  }
+
+  const expiresAt = Number(exp)
+
+  if (!Number.isSafeInteger(expiresAt)) {
+    return false
+  }
+
+  const expected = createSignature(`admin:${exp}`, secret)
+
+  return (
+    signaturesMatch(sig, expected) &&
+    Math.floor(now.getTime() / 1000) <= expiresAt
+  )
+}

--- a/apps/web/lib/resume/token.types.ts
+++ b/apps/web/lib/resume/token.types.ts
@@ -1,0 +1,19 @@
+export type ResumeDoc = 'rirekisho' | 'shokumu-keirekisho'
+export type ResumeFormat = 'pdf' | 'xlsx'
+
+export type ResumeFile = {
+  doc: ResumeDoc
+  format: ResumeFormat
+}
+
+export type ResumeFileId = `${ResumeDoc}-${ResumeFormat}`
+
+export type ResumeToken = {
+  id: ResumeFileId
+  exp: number
+  sig: string
+}
+
+export type VerifyResult =
+  | { ok: true; id: ResumeFileId }
+  | { ok: false; reason: 'expired' | 'invalid' }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
     "lint": "biome check .",
     "lint:fix": "biome check --write ."
   },
@@ -13,6 +14,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@repo/resend": "workspace:*",
     "@repo/ui": "workspace:*",
+    "@vercel/blob": "^2.6.1",
     "autoprefixer": "^10.4.22",
     "framer-motion": "^12.23.25",
     "next": "16.2.10",
@@ -31,6 +33,7 @@
     "@types/node": "^24.10.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@vercel/blob':
+        specifier: ^2.6.1
+        version: 2.6.1
       autoprefixer:
         specifier: ^10.4.22
         version: 10.5.2(postcss@8.5.18)
@@ -71,7 +74,7 @@ importers:
         version: 4.3.2
       zod:
         specifier: ^4.1.13
-        version: 4.4.3
+        version: 4.1.13
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
@@ -88,6 +91,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))
 
   packages/resend:
     dependencies:
@@ -377,8 +383,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -1171,6 +1186,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.1.7':
     resolution: {integrity: sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==}
 
@@ -1280,6 +1301,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -1892,6 +1916,104 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
@@ -1900,6 +2022,9 @@ packages:
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -2228,8 +2353,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2250,6 +2387,50 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@vercel/blob@2.6.1':
+    resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -2281,6 +2462,13 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   atomically@2.1.0:
     resolution: {integrity: sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==}
@@ -2324,6 +2512,10 @@ packages:
 
   caniuse-lite@1.0.30001805:
     resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2375,6 +2567,9 @@ packages:
   conf@15.0.2:
     resolution: {integrity: sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==}
     engines: {node: '>=20'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -2501,6 +2696,9 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -2520,6 +2718,17 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2532,6 +2741,15 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -2550,6 +2768,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
@@ -2557,6 +2780,10 @@ packages:
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2583,6 +2810,10 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
@@ -2591,6 +2822,10 @@ packages:
     resolution: {integrity: sha512-IvHUjULS2q+BXJdiu4FHkByh3+qSFmkOXQ2ItSfYTtkdUksQc0yNX6f1uDyokzRV71tjpFsFc3ckeYLJXunTGw==}
     engines: {node: '>=0.4.7'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2598,6 +2833,13 @@ packages:
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
@@ -2617,6 +2859,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2803,6 +3048,9 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -2818,6 +3066,10 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2914,6 +3166,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
@@ -2922,6 +3178,14 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2933,6 +3197,10 @@ packages:
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -2953,6 +3221,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
@@ -3091,6 +3363,15 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -3123,6 +3404,12 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3151,8 +3438,14 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3177,6 +3470,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -3216,9 +3513,24 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -3246,6 +3558,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3282,6 +3598,90 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -3291,6 +3691,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@6.2.0:
@@ -3309,6 +3714,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
@@ -3316,6 +3729,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
+  zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3408,7 +3827,23 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.3':
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3910,6 +4345,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.1.7': {}
 
   '@next/env@16.2.10': {}
@@ -3961,6 +4403,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
+
+  '@oxc-project/types@0.139.0': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -4523,6 +4967,57 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
       domhandler: 5.0.3
@@ -4531,6 +5026,8 @@ snapshots:
   '@socket.io/component-emitter@3.1.2': {}
 
   '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -4842,9 +5339,23 @@ snapshots:
   '@turbo/windows-arm64@2.10.4':
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 24.13.3
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -4865,6 +5376,71 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@vercel/blob@2.6.1':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.27.0
+
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   accepts@1.3.8:
     dependencies:
@@ -4893,6 +5469,12 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   atomically@2.1.0:
     dependencies:
@@ -4931,6 +5513,8 @@ snapshots:
   caniuse-lite@1.0.30001761: {}
 
   caniuse-lite@1.0.30001805: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -4977,6 +5561,8 @@ snapshots:
       json-schema-typed: 8.0.2
       semver: 7.7.3
       uint8array-extras: 1.5.0
+
+  convert-source-map@2.0.0: {}
 
   cookie@0.7.2: {}
 
@@ -5091,6 +5677,8 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   esbuild@0.27.3:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.3
@@ -5180,6 +5768,24 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  expect-type@1.4.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.1: {}
@@ -5187,6 +5793,10 @@ snapshots:
   fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fraction.js@5.3.4: {}
 
@@ -5199,9 +5809,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  fsevents@2.3.3:
+    optional: true
+
   get-east-asian-width@1.4.0: {}
 
   get-nonce@1.0.1: {}
+
+  get-stream@6.0.1: {}
 
   glob@13.0.6:
     dependencies:
@@ -5232,6 +5847,8 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  human-signals@2.1.0: {}
+
   iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -5240,9 +5857,15 @@ snapshots:
     dependencies:
       daemon: 1.1.0
 
+  is-buffer@2.0.5: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-interactive@2.0.0: {}
+
+  is-node-process@1.2.0: {}
+
+  is-stream@2.0.1: {}
 
   is-unicode-supported@1.3.0: {}
 
@@ -5253,6 +5876,8 @@ snapshots:
   jiti@2.4.2: {}
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5390,6 +6015,8 @@ snapshots:
 
   marked@15.0.12: {}
 
+  merge-stream@2.0.0: {}
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -5401,6 +6028,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -5484,6 +6113,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   nypm@0.6.5:
     dependencies:
       citty: 0.2.2
@@ -5491,6 +6124,12 @@ snapshots:
       tinyexec: 1.2.4
 
   object-assign@4.1.1: {}
+
+  obug@2.1.3: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -5510,6 +6149,8 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
+  os-paths@4.4.0: {}
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -5527,6 +6168,8 @@ snapshots:
   peberminta@0.9.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
 
   postal-mime@2.7.4: {}
 
@@ -5705,6 +6348,29 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.13.1: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
   rope-sequence@1.3.4: {}
 
   safer-buffer@2.1.2: {}
@@ -5757,6 +6423,10 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -5798,10 +6468,14 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -5827,6 +6501,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -5850,7 +6526,18 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  throttleit@2.1.0: {}
+
+  tinybench@2.9.0: {}
+
   tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -5879,6 +6566,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@6.27.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
       browserslist: 4.28.6
@@ -5906,6 +6595,46 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.18
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   when-exit@2.1.5: {}
@@ -5913,6 +6642,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -5922,8 +6656,21 @@ snapshots:
 
   ws@8.17.1: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@4.1.11: {}
+
+  zod@4.1.13: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
## 概要

ポートフォリオから履歴書・職務経歴書（PDF / Excel の4ファイル）を認証付きでダウンロードできるようにする。

## 機能

- **`/resume`** — 共有パスワードを入力すると各書類を即ダウンロード
- **`/admin/resume`** — 管理者ログイン後、有効期限（24h / 7日 / 30日）付きの署名URLを発行。URLを受け取った人はクリックだけでダウンロード可能
- Home の Profile に「経歴書ダウンロード」導線を追加

## 設計

- HMAC-SHA256 署名トークン（`id:exp` を `RESUME_SIGNING_SECRET` で署名）による検証。DB 不要
- パスワード照合・署名比較はいずれも timing-safe
- ファイル本体は **private Vercel Blob** に保管（リポジトリが public のためコミットしない）。認証済みリクエストのみ Route Handler がストリーム配信
- 管理者セッションは httpOnly cookie（HMAC 署名、24h 期限）
- `/resume` `/admin/resume` は noindex

## その他の変更

- vitest 導入（token / password のユニットテスト 11件）
- zod を `~4.1.13` に固定 — Renovate で入った `zod@4.4.3` が `@hookform/resolvers@5.4.0` と型不整合で `next build` が落ちるため

## 検証

- [x] vitest 11件 green / `tsc --noEmit` / `next build` / biome（新規コード由来のエラー 0）
- [x] 本番ビルド + 実 private Blob で4ファイルのDL確認（Content-Type / attachment ヘッダ含む）
- [x] 期限切れ・改ざん署名 403 / 不正 id 400
- [x] UI 2フロー（パスワードDL / 管理画面でURL発行→DL）をブラウザで確認

## デプロイ前の準備

Vercel に env 3つ（`RESUME_PASSWORD` / `RESUME_ADMIN_PASSWORD` / `RESUME_SIGNING_SECRET`）の登録が必要。手順は `apps/web/README.md` 参照。Blob ストア（private）接続済み・ファイルアップロード済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)