### PR TITLE
feat(web): 経歴書ダウンロードを選択式にしてファイル名規約を追加

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -47,6 +47,8 @@ Create the Vercel Blob store with private access. Configure the following server
 
 Vercel ダッシュボード → Storage → Blob で private access のストアを作成し、次の pathname へ4ファイルをアップロードする。
 
+ダウンロード画面では対象ファイルを選択でき、1件なら単体、2件以上なら選択分だけをZIPで配信する。ファイル名には氏名とJSTのダウンロード日時が付与される。
+
 - `resume/rirekisho.pdf`
 - `resume/rirekisho.xlsx`
 - `resume/shokumu-keirekisho.pdf`

--- a/apps/web/actions/resume/issueDownloadUrl/index.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/index.ts
@@ -35,9 +35,9 @@ export async function handler(input: z.infer<typeof schema>) {
     now.getTime() + Number(input.expiresInDays) * 24 * 60 * 60 * 1000
   )
   const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
-  const token = createResumeToken({ id: input.id, expiresAt }, secret)
+  const token = createResumeToken({ ids: input.ids, expiresAt }, secret)
   const searchParams = new URLSearchParams({
-    id: token.id,
+    ids: token.ids.join(','),
     exp: String(token.exp),
     sig: token.sig,
   })

--- a/apps/web/actions/resume/issueDownloadUrl/schema.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/schema.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod'
 
 export const schema = z.object({
-  id: z.enum([
-    'rirekisho-pdf',
-    'rirekisho-xlsx',
-    'shokumu-keirekisho-pdf',
-    'shokumu-keirekisho-xlsx',
-  ]),
+  ids: z
+    .array(
+      z.enum([
+        'rirekisho-pdf',
+        'rirekisho-xlsx',
+        'shokumu-keirekisho-pdf',
+        'shokumu-keirekisho-xlsx',
+      ])
+    )
+    .min(1),
   expiresInDays: z.enum(['1', '7', '30']),
 })

--- a/apps/web/actions/resume/requestDownloadUrl/index.ts
+++ b/apps/web/actions/resume/requestDownloadUrl/index.ts
@@ -17,9 +17,9 @@ export async function handler(input: z.infer<typeof schema>) {
 
   const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
   const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
-  const token = createResumeToken({ id: input.id, expiresAt }, secret)
+  const token = createResumeToken({ ids: input.ids, expiresAt }, secret)
   const searchParams = new URLSearchParams({
-    id: token.id,
+    ids: token.ids.join(','),
     exp: String(token.exp),
     sig: token.sig,
   })

--- a/apps/web/actions/resume/requestDownloadUrl/schema.ts
+++ b/apps/web/actions/resume/requestDownloadUrl/schema.ts
@@ -2,10 +2,14 @@ import { z } from 'zod'
 
 export const schema = z.object({
   password: z.string().min(1),
-  id: z.enum([
-    'rirekisho-pdf',
-    'rirekisho-xlsx',
-    'shokumu-keirekisho-pdf',
-    'shokumu-keirekisho-xlsx',
-  ]),
+  ids: z
+    .array(
+      z.enum([
+        'rirekisho-pdf',
+        'rirekisho-xlsx',
+        'shokumu-keirekisho-pdf',
+        'shokumu-keirekisho-xlsx',
+      ])
+    )
+    .min(1),
 })

--- a/apps/web/app/api/resume/download/route.ts
+++ b/apps/web/app/api/resume/download/route.ts
@@ -1,6 +1,8 @@
 import { get } from '@vercel/blob'
+import { zipSync } from 'fflate'
 
 import { getRequiredResumeEnv } from '~/lib/resume/env'
+import { buildBundleFilename, buildResumeFilename } from '~/lib/resume/filename'
 import { isResumeFileId, verifyResumeToken } from '~/lib/resume/token'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
@@ -9,48 +11,88 @@ export const runtime = 'nodejs'
 const RESUME_FILES = {
   'rirekisho-pdf': {
     pathname: 'resume/rirekisho.pdf',
-    filename: '履歴書.pdf',
     contentType: 'application/pdf',
   },
   'rirekisho-xlsx': {
     pathname: 'resume/rirekisho.xlsx',
-    filename: '履歴書.xlsx',
     contentType:
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   },
   'shokumu-keirekisho-pdf': {
     pathname: 'resume/shokumu-keirekisho.pdf',
-    filename: '職務経歴書.pdf',
     contentType: 'application/pdf',
   },
   'shokumu-keirekisho-xlsx': {
     pathname: 'resume/shokumu-keirekisho.xlsx',
-    filename: '職務経歴書.xlsx',
     contentType:
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   },
-} satisfies Record<
-  ResumeFileId,
-  { pathname: string; filename: string; contentType: string }
->
+} satisfies Record<ResumeFileId, { pathname: string; contentType: string }>
 
 function jsonError(message: string, status: number) {
   return Response.json({ message }, { status })
 }
 
+async function createZipResponse(ids: ResumeFileId[], downloadedAt: Date) {
+  const zipFiles = await Promise.all(
+    ids.map(async (id) => {
+      const resumeFile = RESUME_FILES[id]
+      const blobResult = await get(resumeFile.pathname, {
+        access: 'private',
+      })
+
+      if (blobResult?.statusCode !== 200 || !blobResult?.stream) {
+        return null
+      }
+
+      const arrayBuffer = await new Response(blobResult.stream).arrayBuffer()
+
+      return {
+        filename: buildResumeFilename(id, downloadedAt),
+        data: new Uint8Array(arrayBuffer),
+      }
+    })
+  )
+  const entries: Record<string, Uint8Array> = {}
+
+  for (const zipFile of zipFiles) {
+    if (!zipFile) {
+      return jsonError('ファイルの取得に失敗しました', 502)
+    }
+
+    entries[zipFile.filename] = zipFile.data
+  }
+
+  const zip = zipSync(entries, { level: 0 })
+  const filename = buildBundleFilename(downloadedAt)
+
+  return new Response(zip, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      'Content-Type': 'application/zip',
+      'X-Robots-Tag': 'noindex',
+    },
+  })
+}
+
 export async function GET(request: Request) {
   const searchParams = new URL(request.url).searchParams
-  const id = searchParams.get('id')
+  const idsParameter = searchParams.get('ids')
+  const ids = idsParameter?.split(',') ?? []
   const exp = searchParams.get('exp') ?? ''
   const sig = searchParams.get('sig') ?? ''
 
-  if (!id || !isResumeFileId(id)) {
+  if (
+    ids.length === 0 ||
+    ids.some((resumeFileId) => !isResumeFileId(resumeFileId))
+  ) {
     return jsonError('書類の指定が不正です', 400)
   }
 
   try {
     const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
-    const tokenResult = verifyResumeToken({ id, exp, sig }, secret, new Date())
+    const tokenResult = verifyResumeToken({ ids, exp, sig }, secret, new Date())
 
     if (!tokenResult.ok) {
       return tokenResult.reason === 'expired'
@@ -58,7 +100,14 @@ export async function GET(request: Request) {
         : jsonError('ダウンロードURLが無効です', 403)
     }
 
-    const resumeFile = RESUME_FILES[tokenResult.id]
+    const downloadedAt = new Date()
+
+    if (tokenResult.ids.length >= 2) {
+      return await createZipResponse(tokenResult.ids, downloadedAt)
+    }
+
+    const id = tokenResult.ids[0]
+    const resumeFile = RESUME_FILES[id]
     const blobResult = await get(resumeFile.pathname, {
       access: 'private',
     })
@@ -67,10 +116,12 @@ export async function GET(request: Request) {
       return jsonError('ファイルの取得に失敗しました', 502)
     }
 
+    const filename = buildResumeFilename(id, downloadedAt)
+
     return new Response(blobResult.stream, {
       headers: {
         'Cache-Control': 'no-store',
-        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(resumeFile.filename)}`,
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
         'Content-Type': resumeFile.contentType,
         'X-Robots-Tag': 'noindex',
       },

--- a/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
+++ b/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
@@ -24,6 +24,7 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { issueDownloadUrl } from '~/actions/resume/issueDownloadUrl'
+import { FileSelector } from '~/features/Resume/FileSelector'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
 function getActionError(value: unknown) {
@@ -40,7 +41,7 @@ function getActionError(value: unknown) {
 }
 
 export function AdminPanel() {
-  const [fileId, setFileId] = useState<ResumeFileId>('rirekisho-pdf')
+  const [selectedFileIds, setSelectedFileIds] = useState<ResumeFileId[]>([])
   const [expiresInDays, setExpiresInDays] = useState<'1' | '7' | '30'>('1')
   const [issuedUrl, setIssuedUrl] = useState('')
   const [issuedExpiresAt, setIssuedExpiresAt] = useState('')
@@ -52,7 +53,7 @@ export function AdminPanel() {
     setIsPending(true)
 
     try {
-      const result = await executeAsync({ id: fileId, expiresInDays })
+      const result = await executeAsync({ ids: selectedFileIds, expiresInDays })
       const actionError = getActionError(result?.data)
 
       if (actionError) {
@@ -96,38 +97,12 @@ export function AdminPanel() {
       </CardHeader>
       <form onSubmit={handleIssue}>
         <CardContent className="flex flex-col gap-5">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="resume-document">書類</Label>
-            <Select
-              value={fileId}
-              onValueChange={(value) => {
-                if (
-                  value === 'rirekisho-pdf' ||
-                  value === 'rirekisho-xlsx' ||
-                  value === 'shokumu-keirekisho-pdf' ||
-                  value === 'shokumu-keirekisho-xlsx'
-                ) {
-                  setFileId(value)
-                }
-              }}
-            >
-              <SelectTrigger id="resume-document" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="rirekisho-pdf">履歴書 PDF</SelectItem>
-                  <SelectItem value="rirekisho-xlsx">履歴書 Excel</SelectItem>
-                  <SelectItem value="shokumu-keirekisho-pdf">
-                    職務経歴書 PDF
-                  </SelectItem>
-                  <SelectItem value="shokumu-keirekisho-xlsx">
-                    職務経歴書 Excel
-                  </SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
+          <FileSelector
+            idPrefix="resume-admin"
+            legend="共有するファイル"
+            value={selectedFileIds}
+            onChange={setSelectedFileIds}
+          />
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="resume-expiration">有効期限</Label>
@@ -168,7 +143,11 @@ export function AdminPanel() {
           )}
         </CardContent>
         <CardFooter className="pt-6">
-          <Button type="submit" className="w-full" disabled={isPending}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={selectedFileIds.length === 0 || isPending}
+          >
             {isPending ? '発行中…' : 'URLを発行'}
           </Button>
         </CardFooter>

--- a/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
+++ b/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { requestDownloadUrl } from '~/actions/resume/requestDownloadUrl'
+import { FileSelector } from '~/features/Resume/FileSelector'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
 function getActionError(value: unknown) {
@@ -33,19 +34,20 @@ function getActionError(value: unknown) {
 
 export function DownloadForm() {
   const [password, setPassword] = useState('')
-  const [pendingFileId, setPendingFileId] = useState<ResumeFileId | null>(null)
+  const [selectedFileIds, setSelectedFileIds] = useState<ResumeFileId[]>([])
+  const [isPending, setIsPending] = useState(false)
   const { executeAsync } = useAction(requestDownloadUrl)
 
-  async function handleDownload(id: ResumeFileId) {
+  async function handleDownload() {
     if (!password) {
       toast.error('パスワードを入力してください')
       return
     }
 
-    setPendingFileId(id)
+    setIsPending(true)
 
     try {
-      const result = await executeAsync({ password, id })
+      const result = await executeAsync({ password, ids: selectedFileIds })
       const actionError = getActionError(result?.data)
 
       if (actionError) {
@@ -64,7 +66,7 @@ export function DownloadForm() {
     } catch {
       toast.error('ダウンロードURLを発行できませんでした')
     } finally {
-      setPendingFileId(null)
+      setIsPending(false)
     }
   }
 
@@ -76,7 +78,7 @@ export function DownloadForm() {
           共有されたパスワードを入力し、必要な書類を選んでください。
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex flex-col gap-6">
         <div className="flex flex-col gap-2">
           <Label htmlFor="resume-password">パスワード</Label>
           <Input
@@ -87,48 +89,22 @@ export function DownloadForm() {
             onChange={(event) => setPassword(event.target.value)}
           />
         </div>
+        <FileSelector
+          idPrefix="resume-download"
+          legend="ダウンロードするファイル"
+          value={selectedFileIds}
+          onChange={setSelectedFileIds}
+        />
       </CardContent>
-      <CardFooter className="flex flex-col items-stretch gap-3">
-        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2">
-          <p className="font-medium">履歴書</p>
-          <Button
-            type="button"
-            className="min-w-20"
-            disabled={pendingFileId !== null}
-            onClick={() => handleDownload('rirekisho-pdf')}
-          >
-            {pendingFileId === 'rirekisho-pdf' ? '準備中…' : 'PDF'}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            className="min-w-20"
-            disabled={pendingFileId !== null}
-            onClick={() => handleDownload('rirekisho-xlsx')}
-          >
-            {pendingFileId === 'rirekisho-xlsx' ? '準備中…' : 'Excel'}
-          </Button>
-        </div>
-        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2">
-          <p className="font-medium">職務経歴書</p>
-          <Button
-            type="button"
-            className="min-w-20"
-            disabled={pendingFileId !== null}
-            onClick={() => handleDownload('shokumu-keirekisho-pdf')}
-          >
-            {pendingFileId === 'shokumu-keirekisho-pdf' ? '準備中…' : 'PDF'}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            className="min-w-20"
-            disabled={pendingFileId !== null}
-            onClick={() => handleDownload('shokumu-keirekisho-xlsx')}
-          >
-            {pendingFileId === 'shokumu-keirekisho-xlsx' ? '準備中…' : 'Excel'}
-          </Button>
-        </div>
+      <CardFooter>
+        <Button
+          type="button"
+          className="w-full"
+          disabled={selectedFileIds.length === 0 || isPending}
+          onClick={handleDownload}
+        >
+          {isPending ? '準備中…' : '選択したファイルをダウンロード'}
+        </Button>
       </CardFooter>
     </Card>
   )

--- a/apps/web/features/Resume/FileSelector/FileSelector.types.ts
+++ b/apps/web/features/Resume/FileSelector/FileSelector.types.ts
@@ -1,0 +1,8 @@
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+export type FileSelectorProps = {
+  idPrefix: string
+  legend: string
+  value: ResumeFileId[]
+  onChange: (value: ResumeFileId[]) => void
+}

--- a/apps/web/features/Resume/FileSelector/components/FileSelector.tsx
+++ b/apps/web/features/Resume/FileSelector/components/FileSelector.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Checkbox } from '@repo/ui/components/checkbox'
+import { Label } from '@repo/ui/components/label'
+
+import type { FileSelectorProps } from '~/features/Resume/FileSelector/FileSelector.types'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+const FILE_OPTIONS: { id: ResumeFileId; label: string }[] = [
+  { id: 'rirekisho-pdf', label: '履歴書 PDF' },
+  { id: 'rirekisho-xlsx', label: '履歴書 Excel' },
+  { id: 'shokumu-keirekisho-pdf', label: '職務経歴書 PDF' },
+  { id: 'shokumu-keirekisho-xlsx', label: '職務経歴書 Excel' },
+]
+
+export function FileSelector({
+  idPrefix,
+  legend,
+  value,
+  onChange,
+}: FileSelectorProps) {
+  function handleCheckedChange(id: ResumeFileId, checked: boolean) {
+    if (checked) {
+      if (!value.includes(id)) {
+        onChange([...value, id])
+      }
+      return
+    }
+
+    onChange(value.filter((selectedId) => selectedId !== id))
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-3">
+      <legend className="mb-1 text-sm font-medium">{legend}</legend>
+      {FILE_OPTIONS.map((option) => {
+        const inputId = `${idPrefix}-${option.id}`
+
+        return (
+          <div key={option.id} className="flex items-center gap-2">
+            <Checkbox
+              id={inputId}
+              checked={value.includes(option.id)}
+              onCheckedChange={(checked) =>
+                handleCheckedChange(option.id, checked === true)
+              }
+            />
+            <Label htmlFor={inputId} className="font-normal">
+              {option.label}
+            </Label>
+          </div>
+        )
+      })}
+      <p className="text-sm text-muted-foreground">
+        2件以上を選択するとZIP形式でダウンロードされます。
+      </p>
+    </fieldset>
+  )
+}

--- a/apps/web/features/Resume/FileSelector/index.ts
+++ b/apps/web/features/Resume/FileSelector/index.ts
@@ -1,0 +1,1 @@
+export { FileSelector } from '~/features/Resume/FileSelector/components/FileSelector'

--- a/apps/web/lib/resume/filename.test.ts
+++ b/apps/web/lib/resume/filename.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildBundleFilename,
+  buildResumeFilename,
+  formatResumeTimestamp,
+} from '~/lib/resume/filename'
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+const DOWNLOAD_AT = new Date('2026-07-13T07:39:05.000Z')
+
+describe('resume filename', () => {
+  it('formats a timestamp in Asia/Tokyo', () => {
+    expect(formatResumeTimestamp(DOWNLOAD_AT)).toBe('2026_07_13_16-39-05')
+  })
+
+  it.each<[ResumeFileId, string]>([
+    ['rirekisho-pdf', '林田直樹_履歴書_2026_07_13_16-39-05.pdf'],
+    ['rirekisho-xlsx', '林田直樹_履歴書_2026_07_13_16-39-05.xlsx'],
+    ['shokumu-keirekisho-pdf', '林田直樹_職務経歴書_2026_07_13_16-39-05.pdf'],
+    ['shokumu-keirekisho-xlsx', '林田直樹_職務経歴書_2026_07_13_16-39-05.xlsx'],
+  ])('builds the filename for %s', (id, expected) => {
+    expect(buildResumeFilename(id, DOWNLOAD_AT)).toBe(expected)
+  })
+
+  it('builds the bundle filename', () => {
+    expect(buildBundleFilename(DOWNLOAD_AT)).toBe(
+      '林田直樹_2026_07_13_16-39-05.zip'
+    )
+  })
+})

--- a/apps/web/lib/resume/filename.ts
+++ b/apps/web/lib/resume/filename.ts
@@ -1,0 +1,56 @@
+import type { ResumeFileId } from '~/lib/resume/token.types'
+
+export const OWNER_NAME = '林田直樹'
+
+const RESUME_FILE_NAMES = {
+  'rirekisho-pdf': { label: '履歴書', extension: 'pdf' },
+  'rirekisho-xlsx': { label: '履歴書', extension: 'xlsx' },
+  'shokumu-keirekisho-pdf': { label: '職務経歴書', extension: 'pdf' },
+  'shokumu-keirekisho-xlsx': { label: '職務経歴書', extension: 'xlsx' },
+} satisfies Record<ResumeFileId, { label: string; extension: string }>
+
+type TimestampPart = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second'
+
+function getTimestampPart(
+  parts: Intl.DateTimeFormatPart[],
+  type: TimestampPart
+) {
+  const value = parts.find((part) => part.type === type)?.value
+
+  if (!value) {
+    throw new Error(`Missing resume timestamp part: ${type}`)
+  }
+
+  return value
+}
+
+export function formatResumeTimestamp(date: Date) {
+  const parts = new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const year = getTimestampPart(parts, 'year')
+  const month = getTimestampPart(parts, 'month')
+  const day = getTimestampPart(parts, 'day')
+  const hour = getTimestampPart(parts, 'hour')
+  const minute = getTimestampPart(parts, 'minute')
+  const second = getTimestampPart(parts, 'second')
+
+  return `${year}_${month}_${day}_${hour}-${minute}-${second}`
+}
+
+export function buildResumeFilename(id: ResumeFileId, date: Date) {
+  const file = RESUME_FILE_NAMES[id]
+
+  return `${OWNER_NAME}_${file.label}_${formatResumeTimestamp(date)}.${file.extension}`
+}
+
+export function buildBundleFilename(date: Date) {
+  return `${OWNER_NAME}_${formatResumeTimestamp(date)}.zip`
+}

--- a/apps/web/lib/resume/token.test.ts
+++ b/apps/web/lib/resume/token.test.ts
@@ -1,47 +1,134 @@
 import { describe, expect, it } from 'vitest'
 
 import { createResumeToken, verifyResumeToken } from '~/lib/resume/token'
-import type { ResumeFileId } from '~/lib/resume/token.types'
 
 const SECRET = 'test-signing-secret'
 const CREATED_AT = new Date('2026-07-13T00:00:00.000Z')
 const EXPIRES_AT = new Date('2026-07-13T00:05:00.000Z')
-const FILE_IDS: ResumeFileId[] = [
-  'rirekisho-pdf',
-  'rirekisho-xlsx',
-  'shokumu-keirekisho-pdf',
-  'shokumu-keirekisho-xlsx',
-]
 
 describe('resume token', () => {
-  it.each(
-    FILE_IDS
-  )('creates a token that verifies with the same file: %s', (id) => {
-    const token = createResumeToken({ id, expiresAt: EXPIRES_AT }, SECRET)
-
-    expect(
-      verifyResumeToken(
-        {
-          id: token.id,
-          exp: String(token.exp),
-          sig: token.sig,
-        },
-        SECRET,
-        CREATED_AT
-      )
-    ).toEqual({ ok: true, id })
-  })
-
-  it('rejects an expired token', () => {
+  it('creates and verifies a token for one file', () => {
     const token = createResumeToken(
-      { id: 'rirekisho-pdf', expiresAt: EXPIRES_AT },
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
       SECRET
     )
 
     expect(
       verifyResumeToken(
         {
-          id: token.id,
+          ids: token.ids,
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: true, ids: ['rirekisho-pdf'] })
+  })
+
+  it('creates and verifies a token for multiple files', () => {
+    const token = createResumeToken(
+      {
+        ids: ['rirekisho-xlsx', 'shokumu-keirekisho-pdf'],
+        expiresAt: EXPIRES_AT,
+      },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          ids: token.ids,
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({
+      ok: true,
+      ids: ['rirekisho-xlsx', 'shokumu-keirekisho-pdf'],
+    })
+  })
+
+  it('uses the same signature regardless of order or duplicates', () => {
+    const first = createResumeToken(
+      {
+        ids: ['shokumu-keirekisho-pdf', 'rirekisho-pdf', 'rirekisho-pdf'],
+        expiresAt: EXPIRES_AT,
+      },
+      SECRET
+    )
+    const second = createResumeToken(
+      {
+        ids: ['rirekisho-pdf', 'shokumu-keirekisho-pdf'],
+        expiresAt: EXPIRES_AT,
+      },
+      SECRET
+    )
+
+    expect(first.sig).toBe(second.sig)
+    expect(first.ids).toEqual(['rirekisho-pdf', 'shokumu-keirekisho-pdf'])
+    expect(
+      verifyResumeToken(
+        {
+          ids: ['shokumu-keirekisho-pdf', 'rirekisho-pdf'],
+          exp: String(first.exp),
+          sig: first.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({
+      ok: true,
+      ids: ['rirekisho-pdf', 'shokumu-keirekisho-pdf'],
+    })
+  })
+
+  it('rejects an empty file list', () => {
+    const token = createResumeToken(
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        { ids: [], exp: String(token.exp), sig: token.sig },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  it('rejects a list containing an invalid file ID', () => {
+    const token = createResumeToken(
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          ids: ['rirekisho-pdf', 'invalid-file'],
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  it('rejects an expired token', () => {
+    const token = createResumeToken(
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          ids: token.ids,
           exp: String(token.exp),
           sig: token.sig,
         },
@@ -54,35 +141,32 @@ describe('resume token', () => {
   it.each([
     {
       name: 'signature',
-      id: 'rirekisho-pdf',
+      ids: ['rirekisho-pdf'],
       signature: 'tampered',
       secret: SECRET,
     },
     {
-      name: 'file',
-      id: 'shokumu-keirekisho-pdf',
+      name: 'file list',
+      ids: ['shokumu-keirekisho-pdf'],
       signature: undefined,
       secret: SECRET,
     },
     {
       name: 'secret',
-      id: 'rirekisho-pdf',
+      ids: ['rirekisho-pdf'],
       signature: undefined,
       secret: 'different-secret',
     },
-  ])('rejects a token with a tampered $name', ({ id, signature, secret }) => {
+  ])('rejects a token with a tampered $name', ({ ids, signature, secret }) => {
     const token = createResumeToken(
-      {
-        id: 'rirekisho-pdf',
-        expiresAt: EXPIRES_AT,
-      },
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
       SECRET
     )
 
     expect(
       verifyResumeToken(
         {
-          id,
+          ids,
           exp: String(token.exp),
           sig: signature ?? token.sig,
         },

--- a/apps/web/lib/resume/token.ts
+++ b/apps/web/lib/resume/token.ts
@@ -26,22 +26,48 @@ export function isResumeFileId(value: string): value is ResumeFileId {
   )
 }
 
+function normalizeResumeFileIds(ids: readonly string[]) {
+  if (ids.length === 0) {
+    return null
+  }
+
+  const normalizedIds = new Set<ResumeFileId>()
+
+  for (const id of ids) {
+    if (!isResumeFileId(id)) {
+      return null
+    }
+
+    normalizedIds.add(id)
+  }
+
+  return Array.from(normalizedIds).sort()
+}
+
 export function createResumeToken(
-  input: { id: ResumeFileId; expiresAt: Date },
+  input: { ids: ResumeFileId[]; expiresAt: Date },
   secret: string
 ): ResumeToken {
-  const exp = Math.floor(input.expiresAt.getTime() / 1000)
-  const sig = createSignature(`${input.id}:${exp}`, secret)
+  const ids = normalizeResumeFileIds(input.ids)
 
-  return { id: input.id, exp, sig }
+  if (!ids) {
+    throw new Error('At least one resume file is required')
+  }
+
+  const exp = Math.floor(input.expiresAt.getTime() / 1000)
+  const sig = createSignature(`${ids.join(',')}:${exp}`, secret)
+
+  return { ids, exp, sig }
 }
 
 export function verifyResumeToken(
-  token: { id: string; exp: string; sig: string },
+  token: { ids: string[]; exp: string; sig: string },
   secret: string,
   now: Date
 ): VerifyResult {
-  if (!isResumeFileId(token.id) || !/^\d+$/.test(token.exp)) {
+  const ids = normalizeResumeFileIds(token.ids)
+
+  if (!ids || !/^\d+$/.test(token.exp)) {
     return { ok: false, reason: 'invalid' }
   }
 
@@ -51,7 +77,7 @@ export function verifyResumeToken(
     return { ok: false, reason: 'invalid' }
   }
 
-  const expected = createSignature(`${token.id}:${token.exp}`, secret)
+  const expected = createSignature(`${ids.join(',')}:${token.exp}`, secret)
 
   if (!signaturesMatch(token.sig, expected)) {
     return { ok: false, reason: 'invalid' }
@@ -61,7 +87,7 @@ export function verifyResumeToken(
     return { ok: false, reason: 'expired' }
   }
 
-  return { ok: true, id: token.id }
+  return { ok: true, ids }
 }
 
 export function createAdminSessionToken(expiresAt: Date, secret: string) {

--- a/apps/web/lib/resume/token.types.ts
+++ b/apps/web/lib/resume/token.types.ts
@@ -9,11 +9,11 @@ export type ResumeFile = {
 export type ResumeFileId = `${ResumeDoc}-${ResumeFormat}`
 
 export type ResumeToken = {
-  id: ResumeFileId
+  ids: ResumeFileId[]
   exp: number
   sig: string
 }
 
 export type VerifyResult =
-  | { ok: true; id: ResumeFileId }
+  | { ok: true; ids: ResumeFileId[] }
   | { ok: false; reason: 'expired' | 'invalid' }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@repo/ui": "workspace:*",
     "@vercel/blob": "^2.6.1",
     "autoprefixer": "^10.4.22",
+    "fflate": "^0.8.3",
     "framer-motion": "^12.23.25",
     "next": "16.2.10",
     "next-safe-action": "^8.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.22
         version: 10.5.2(postcss@8.5.18)
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       framer-motion:
         specifier: ^12.23.25
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2750,6 +2753,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -5797,6 +5803,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   fraction.js@5.3.4: {}
 


### PR DESCRIPTION
## 概要

#77 の続き。ダウンロード対象をチェックボックスで選択できるようにし、ファイル名に氏名とダウンロード時刻を入れる。

## 変更

- 4ファイル（履歴書/職務経歴書 × PDF/Excel）をチェックボックスで選択して一括DL
- 1件選択は単体ファイル、複数選択は fflate で ZIP 配信
- 署名トークンを複数ID対応（ソート・重複排除で正規化して署名）
- ファイル名: `林田直樹_<書類名>_YYYY_MM_DD_HH-mm-ss.<ext>`（JST・DL時刻、`:` は Windows 禁止文字のため `-`）
- ZIP名: `林田直樹_YYYY_MM_DD_HH-mm-ss.zip`

## 検証

- [x] vitest 18件 green / `tsc --noEmit` / `next build` / biome
- [x] 実 private Blob で単体DL・複数選択ZIP（中身のファイル名含む）を確認
- [x] ids の順序入れ替えでも署名一致、改ざん（別集合の署名流用）は 403
- [x] チェックボックスUIの実ブラウザ確認（未選択時 disabled、選択→DL 200）

🤖 Generated with [Claude Code](https://claude.com/claude-code)