### PR TITLE
feat(web): パスワード保護付き 履歴書・職務経歴書・本人確認書類ダウンロード

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -45,7 +45,7 @@ Create the Vercel Blob store with private access. Configure the following server
 
 ### Uploading the resume files
 
-Vercel ダッシュボード → Storage → Blob で private access のストアを作成し、次の pathname へ4ファイルをアップロードする。
+Vercel ダッシュボード → Storage → Blob で private access のストアを作成し、次の pathname へ5ファイルをアップロードする。
 
 ダウンロード画面では対象ファイルを選択でき、1件なら単体、2件以上なら選択分だけをZIPで配信する。ファイル名には氏名とJSTのダウンロード日時が付与される。
 
@@ -53,6 +53,9 @@ Vercel ダッシュボード → Storage → Blob で private access のスト�
 - `resume/rirekisho.xlsx`
 - `resume/shokumu-keirekisho.pdf`
 - `resume/shokumu-keirekisho.xlsx`
+- `resume/mynumber.pdf`（マイナンバーカード両面を1枚にまとめたPDF）
+
+`resume/mynumber.pdf` のダウンロードURLは `/admin/resume` からのみ発行でき、公開の `/resume` フォームからは発行できない。
 
 `RESUME_SIGNING_SECRET` は `openssl rand -base64 32` などで十分に長いランダム値を生成する。
 

--- a/apps/web/actions/resume/issueDownloadUrl/schema.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/schema.ts
@@ -4,6 +4,7 @@ export const schema = z.object({
   ids: z
     .array(
       z.enum([
+        'mynumber-pdf',
         'rirekisho-pdf',
         'rirekisho-xlsx',
         'shokumu-keirekisho-pdf',

--- a/apps/web/actions/resume/schemas.test.ts
+++ b/apps/web/actions/resume/schemas.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { schema as issueDownloadUrlSchema } from '~/actions/resume/issueDownloadUrl/schema'
+import { schema as requestDownloadUrlSchema } from '~/actions/resume/requestDownloadUrl/schema'
+
+describe('resume download schemas', () => {
+  it('allows the admin action to issue a My Number card URL', () => {
+    expect(
+      issueDownloadUrlSchema.safeParse({
+        ids: ['mynumber-pdf'],
+        expiresInDays: '1',
+      }).success
+    ).toBe(true)
+  })
+
+  it('prevents the public action from requesting a My Number card URL', () => {
+    expect(
+      requestDownloadUrlSchema.safeParse({
+        password: 'shared-password',
+        ids: ['mynumber-pdf'],
+      }).success
+    ).toBe(false)
+  })
+})

--- a/apps/web/app/api/resume/download/route.ts
+++ b/apps/web/app/api/resume/download/route.ts
@@ -9,6 +9,10 @@ import type { ResumeFileId } from '~/lib/resume/token.types'
 export const runtime = 'nodejs'
 
 const RESUME_FILES = {
+  'mynumber-pdf': {
+    pathname: 'resume/mynumber.pdf',
+    contentType: 'application/pdf',
+  },
   'rirekisho-pdf': {
     pathname: 'resume/rirekisho.pdf',
     contentType: 'application/pdf',

--- a/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
+++ b/apps/web/features/Resume/AdminPanel/components/AdminPanel.tsx
@@ -24,7 +24,10 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { issueDownloadUrl } from '~/actions/resume/issueDownloadUrl'
-import { FileSelector } from '~/features/Resume/FileSelector'
+import {
+  ADMIN_FILE_OPTIONS,
+  FileSelector,
+} from '~/features/Resume/FileSelector'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
 function getActionError(value: unknown) {
@@ -100,6 +103,7 @@ export function AdminPanel() {
           <FileSelector
             idPrefix="resume-admin"
             legend="共有するファイル"
+            options={ADMIN_FILE_OPTIONS}
             value={selectedFileIds}
             onChange={setSelectedFileIds}
           />

--- a/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
+++ b/apps/web/features/Resume/DownloadForm/components/DownloadForm.tsx
@@ -16,7 +16,10 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { requestDownloadUrl } from '~/actions/resume/requestDownloadUrl'
-import { FileSelector } from '~/features/Resume/FileSelector'
+import {
+  FileSelector,
+  PUBLIC_FILE_OPTIONS,
+} from '~/features/Resume/FileSelector'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
 function getActionError(value: unknown) {
@@ -92,6 +95,7 @@ export function DownloadForm() {
         <FileSelector
           idPrefix="resume-download"
           legend="ダウンロードするファイル"
+          options={PUBLIC_FILE_OPTIONS}
           value={selectedFileIds}
           onChange={setSelectedFileIds}
         />

--- a/apps/web/features/Resume/FileSelector/FileSelector.types.ts
+++ b/apps/web/features/Resume/FileSelector/FileSelector.types.ts
@@ -1,8 +1,14 @@
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
+export type ResumeFileOption = {
+  id: ResumeFileId
+  label: string
+}
+
 export type FileSelectorProps = {
   idPrefix: string
   legend: string
+  options: ResumeFileOption[]
   value: ResumeFileId[]
   onChange: (value: ResumeFileId[]) => void
 }

--- a/apps/web/features/Resume/FileSelector/components/FileSelector.tsx
+++ b/apps/web/features/Resume/FileSelector/components/FileSelector.tsx
@@ -3,19 +3,31 @@
 import { Checkbox } from '@repo/ui/components/checkbox'
 import { Label } from '@repo/ui/components/label'
 
-import type { FileSelectorProps } from '~/features/Resume/FileSelector/FileSelector.types'
+import type {
+  FileSelectorProps,
+  ResumeFileOption,
+} from '~/features/Resume/FileSelector/FileSelector.types'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
-const FILE_OPTIONS: { id: ResumeFileId; label: string }[] = [
+export const PUBLIC_FILE_OPTIONS: ResumeFileOption[] = [
   { id: 'rirekisho-pdf', label: '履歴書 PDF' },
   { id: 'rirekisho-xlsx', label: '履歴書 Excel' },
   { id: 'shokumu-keirekisho-pdf', label: '職務経歴書 PDF' },
   { id: 'shokumu-keirekisho-xlsx', label: '職務経歴書 Excel' },
 ]
 
+export const ADMIN_FILE_OPTIONS: ResumeFileOption[] = [
+  ...PUBLIC_FILE_OPTIONS,
+  {
+    id: 'mynumber-pdf',
+    label: '本人確認書類（マイナンバーカード両面 PDF）',
+  },
+]
+
 export function FileSelector({
   idPrefix,
   legend,
+  options,
   value,
   onChange,
 }: FileSelectorProps) {
@@ -33,7 +45,7 @@ export function FileSelector({
   return (
     <fieldset className="flex flex-col gap-3">
       <legend className="mb-1 text-sm font-medium">{legend}</legend>
-      {FILE_OPTIONS.map((option) => {
+      {options.map((option) => {
         const inputId = `${idPrefix}-${option.id}`
 
         return (

--- a/apps/web/features/Resume/FileSelector/index.ts
+++ b/apps/web/features/Resume/FileSelector/index.ts
@@ -1,1 +1,6 @@
-export { FileSelector } from '~/features/Resume/FileSelector/components/FileSelector'
+export {
+  ADMIN_FILE_OPTIONS,
+  FileSelector,
+  PUBLIC_FILE_OPTIONS,
+} from '~/features/Resume/FileSelector/components/FileSelector'
+export type { ResumeFileOption } from '~/features/Resume/FileSelector/FileSelector.types'

--- a/apps/web/lib/resume/filename.test.ts
+++ b/apps/web/lib/resume/filename.test.ts
@@ -19,6 +19,7 @@ describe('resume filename', () => {
     ['rirekisho-xlsx', '林田直樹_履歴書_2026_07_13_16-39-05.xlsx'],
     ['shokumu-keirekisho-pdf', '林田直樹_職務経歴書_2026_07_13_16-39-05.pdf'],
     ['shokumu-keirekisho-xlsx', '林田直樹_職務経歴書_2026_07_13_16-39-05.xlsx'],
+    ['mynumber-pdf', '林田直樹_本人確認書類_2026_07_13_16-39-05.pdf'],
   ])('builds the filename for %s', (id, expected) => {
     expect(buildResumeFilename(id, DOWNLOAD_AT)).toBe(expected)
   })

--- a/apps/web/lib/resume/filename.ts
+++ b/apps/web/lib/resume/filename.ts
@@ -3,6 +3,7 @@ import type { ResumeFileId } from '~/lib/resume/token.types'
 export const OWNER_NAME = '林田直樹'
 
 const RESUME_FILE_NAMES = {
+  'mynumber-pdf': { label: '本人確認書類', extension: 'pdf' },
   'rirekisho-pdf': { label: '履歴書', extension: 'pdf' },
   'rirekisho-xlsx': { label: '履歴書', extension: 'xlsx' },
   'shokumu-keirekisho-pdf': { label: '職務経歴書', extension: 'pdf' },

--- a/apps/web/lib/resume/token.test.ts
+++ b/apps/web/lib/resume/token.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { createResumeToken, verifyResumeToken } from '~/lib/resume/token'
+import {
+  createResumeToken,
+  isResumeFileId,
+  verifyResumeToken,
+} from '~/lib/resume/token'
 
 const SECRET = 'test-signing-secret'
 const CREATED_AT = new Date('2026-07-13T00:00:00.000Z')
@@ -24,6 +28,25 @@ describe('resume token', () => {
         CREATED_AT
       )
     ).toEqual({ ok: true, ids: ['rirekisho-pdf'] })
+  })
+
+  it('creates and verifies a token for a My Number card', () => {
+    const token = createResumeToken(
+      { ids: ['mynumber-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+
+    expect(
+      verifyResumeToken(
+        {
+          ids: token.ids,
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: true, ids: ['mynumber-pdf'] })
   })
 
   it('creates and verifies a token for multiple files', () => {
@@ -83,6 +106,33 @@ describe('resume token', () => {
       ok: true,
       ids: ['rirekisho-pdf', 'shokumu-keirekisho-pdf'],
     })
+  })
+
+  it('normalizes a My Number card mixed with a resume file', () => {
+    const token = createResumeToken(
+      {
+        ids: ['rirekisho-pdf', 'mynumber-pdf', 'mynumber-pdf'],
+        expiresAt: EXPIRES_AT,
+      },
+      SECRET
+    )
+
+    expect(token.ids).toEqual(['mynumber-pdf', 'rirekisho-pdf'])
+    expect(
+      verifyResumeToken(
+        {
+          ids: ['rirekisho-pdf', 'mynumber-pdf'],
+          exp: String(token.exp),
+          sig: token.sig,
+        },
+        SECRET,
+        CREATED_AT
+      )
+    ).toEqual({ ok: true, ids: ['mynumber-pdf', 'rirekisho-pdf'] })
+  })
+
+  it('recognizes the My Number card file ID', () => {
+    expect(isResumeFileId('mynumber-pdf')).toBe(true)
   })
 
   it('rejects an empty file list', () => {

--- a/apps/web/lib/resume/token.ts
+++ b/apps/web/lib/resume/token.ts
@@ -19,6 +19,7 @@ function signaturesMatch(actual: string, expected: string) {
 
 export function isResumeFileId(value: string): value is ResumeFileId {
   return (
+    value === 'mynumber-pdf' ||
     value === 'rirekisho-pdf' ||
     value === 'rirekisho-xlsx' ||
     value === 'shokumu-keirekisho-pdf' ||

--- a/apps/web/lib/resume/token.types.ts
+++ b/apps/web/lib/resume/token.types.ts
@@ -6,7 +6,7 @@ export type ResumeFile = {
   format: ResumeFormat
 }
 
-export type ResumeFileId = `${ResumeDoc}-${ResumeFormat}`
+export type ResumeFileId = `${ResumeDoc}-${ResumeFormat}` | 'mynumber-pdf'
 
 export type ResumeToken = {
   ids: ResumeFileId[]

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,14 @@
     },
     "dev": {
       "cache": false,
-      "env": ["RESEND_API_KEY", "ADMIN_EMAIL"]
+      "env": [
+        "RESEND_API_KEY",
+        "ADMIN_EMAIL",
+        "RESUME_PASSWORD",
+        "RESUME_ADMIN_PASSWORD",
+        "RESUME_SIGNING_SECRET",
+        "BLOB_STORE_ID"
+      ]
     },
     "clean": {
       "cache": false
@@ -22,6 +29,11 @@
     "NEXT_PUBLIC_*",
     "!NEXT_PUBLIC_VERCEL_*",
     "RESEND_API_KEY",
-    "ADMIN_EMAIL"
-  ]
+    "ADMIN_EMAIL",
+    "RESUME_PASSWORD",
+    "RESUME_ADMIN_PASSWORD",
+    "RESUME_SIGNING_SECRET",
+    "BLOB_STORE_ID"
+  ],
+  "globalPassThroughEnv": ["VERCEL_OIDC_TOKEN"]
 }


### PR DESCRIPTION
## Summary

経歴書類と本人確認書類を安全に共有するためのダウンロード機能を追加します。

### 公開ページ `/resume`
- 共有パスワード入力で 履歴書・職務経歴書 (PDF/Excel) を即ダウンロード (5分有効の署名URL)
- チェックボックスで選択式、1件は単体・2件以上は fflate による無圧縮ZIP配信

### 管理ページ `/admin/resume`
- 管理者パスワードでログイン (24時間の署名cookieセッション)
- 有効期限付き (24時間/7日/30日) の共有用署名URLを発行
- 本人確認書類 (マイナンバーカード両面1枚PDF) は **admin発行URLのみ** で共有可能

### 基盤
- HMAC-SHA256 署名トークン (DB不要)、timing-safe なパスワード照合
- ファイルは private Vercel Blob に保管し、Route Handler 経由でストリーム配信 (リポジトリには含めない)
- DLファイル名は `林田直樹_<書類名>_YYYY_MM_DD_HH-mm-ss.<ext>` (JST・DL時刻)

### セキュリティ境界
マイナンバーカードは公開側 `requestDownloadUrl` の zod schema と公開フォームの選択肢に含めないことで、発行段階から admin 限定。この境界は `apps/web/actions/resume/schemas.test.ts` でテスト固定。

## Test plan

- [x] vitest 24件パス (token署名/検証・ファイル名規約・schema境界)
- [x] `tsc --noEmit` / Biome (変更ファイル) クリーン
- [ ] デプロイ後: Vercel Blob に5ファイル (`resume/*.pdf|xlsx`, `resume/mynumber.pdf`) 配置済みで各DL動作確認
- [ ] Vercel 環境変数 `RESUME_PASSWORD` / `RESUME_ADMIN_PASSWORD` / `RESUME_SIGNING_SECRET` / `BLOB_STORE_ID` 設定確認 (`RESUME_ADMIN_PASSWORD` は 1Password の新しい値に更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)