### PR TITLE
feat(web): 職務経歴書ベースにプロジェクト・スキル・About を更新

### DIFF
--- a/apps/web/features/Home/FlightLog/flightLog.test.ts
+++ b/apps/web/features/Home/FlightLog/flightLog.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
+import { DESTINATION_LABELS } from '~/features/Home/destination'
 import {
   clientProjects,
   personalProjects,
 } from '~/features/Home/ProjectTimeLIne/config'
 import type { TimeLineItem } from '~/features/Home/ProjectTimeLIne/type'
 
-import {
-  DESTINATION_LABELS,
-  FALLBACK_DESTINATION,
-  toFlightLog,
-} from './flightLog'
+import { FALLBACK_DESTINATION, toFlightLog } from './flightLog'
 
 const realProjects: Array<TimeLineItem> = [
   ...clientProjects,
@@ -22,26 +19,17 @@ describe('toFlightLog', () => {
     const entries = toFlightLog(realProjects)
 
     expect(entries).toHaveLength(realProjects.length)
-    expect(entries.map((entry) => entry.flightNo)).toEqual([
-      'FL-001',
-      'FL-002',
-      'FL-003',
-      'FL-004',
-      'FL-005',
-    ])
+    expect(entries[0]?.flightNo).toBe('FL-001')
+    expect(entries.at(-1)?.flightNo).toBe(
+      `FL-${String(realProjects.length).padStart(3, '0')}`
+    )
   })
 
   it('orders flights from the most recent start period', () => {
     const entries = toFlightLog(realProjects)
 
-    expect(entries.map((entry) => entry.year)).toEqual([
-      '2024',
-      '2024',
-      '2023',
-      '2023',
-      '2023',
-    ])
-    expect(entries[0]?.project).toBe('ポートフォリオサイト')
+    expect(entries[0]?.project).toBe('Resme(レスミー)プロダクト開発')
+    expect(entries.at(-1)?.project).toBe('POS アプリケーション管理サービス開発')
   })
 
   it('extracts the start year from the period string', () => {
@@ -50,7 +38,7 @@ describe('toFlightLog', () => {
         title: '会計事務所向け AI SaaS',
         description: '',
         period: '2024.06 - 現在',
-        role: 'インターン',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
     ])
@@ -64,35 +52,35 @@ describe('toFlightLog', () => {
         title: '弁護士事務所向け債務整理サービス',
         description: '',
         period: '2025.01 - 現在',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
       {
         title: '会計事務所の業務改善アプリケーション',
         description: '',
         period: '2024.06 - 2024.12',
-        role: 'インターン',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
       {
         title: '住宅設備メーカー向け見積もりツール',
         description: '',
         period: '2023.04 - 2023.10',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
       {
         title: '社内勤怠管理サービス',
         description: '',
         period: '2022.09 - 2022.12',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
       {
         title: 'ライブ配信プラットフォーム',
         description: '',
         period: '2021.05 - 2021.11',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
     ])
@@ -107,20 +95,97 @@ describe('toFlightLog', () => {
     expect(entries[0]?.destinationLabel).toBe(DESTINATION_LABELS.LAW)
   })
 
+  it('prefers an explicit destination over the keyword inference', () => {
+    const [entry] = toFlightLog([
+      {
+        title: 'Resme(レスミー)プロダクト開発',
+        description: '',
+        period: '2025.08 - 2026.04',
+        role: 'フルスタックエンジニア(開発責任者)',
+        skills: [],
+        destination: 'CAR',
+      },
+    ])
+
+    expect(entry?.destination).toBe('CAR')
+    expect(entry?.destinationLabel).toBe(DESTINATION_LABELS.CAR)
+  })
+
+  it('overrides a keyword match when an explicit destination is given', () => {
+    const [entry] = toFlightLog([
+      {
+        title: '会計事務所向け AI SaaS 開発',
+        description: '',
+        period: '2024.06 - 2025.06',
+        role: 'フロントエンドエンジニア',
+        skills: [],
+        destination: 'LAW',
+      },
+    ])
+
+    expect(entry?.destination).toBe('LAW')
+  })
+
+  it('falls back to the keyword inference when no destination is given', () => {
+    const [entry] = toFlightLog([
+      {
+        title: '会計事務所向け AI SaaS 開発',
+        description: '',
+        period: '2024.06 - 2025.06',
+        role: 'フロントエンドエンジニア',
+        skills: [],
+      },
+    ])
+
+    expect(entry?.destination).toBe('ACC')
+  })
+
+  it('keeps the original array order for projects that start in the same month', () => {
+    const entries = toFlightLog([
+      {
+        title: '先に並べた案件',
+        description: '',
+        period: '2025.08 - 2026.04',
+        role: 'フロントエンドエンジニア',
+        skills: [],
+      },
+      {
+        title: '後に並べた案件',
+        description: '',
+        period: '2025.08 - 2025.12',
+        role: 'フロントエンドエンジニア',
+        skills: [],
+      },
+      {
+        title: 'さらに後に並べた案件',
+        description: '',
+        period: '2025.08 - 2025.10',
+        role: 'フロントエンドエンジニア',
+        skills: [],
+      },
+    ])
+
+    expect(entries.map((entry) => entry.project)).toEqual([
+      '先に並べた案件',
+      '後に並べた案件',
+      'さらに後に並べた案件',
+    ])
+  })
+
   it('marks a period that has no end date as active', () => {
     const entries = toFlightLog([
       {
         title: '継続案件',
         description: '',
         period: '2024.06 - 現在',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
       {
         title: '終了案件',
         description: '',
         period: '2023.01 - 2023.06',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
     ])
@@ -154,7 +219,7 @@ describe('toFlightLog', () => {
         title: '年不明の案件',
         description: '',
         period: '期間非公開',
-        role: '業務委託',
+        role: 'フロントエンドエンジニア',
         skills: [],
       },
     ])

--- a/apps/web/features/Home/FlightLog/flightLog.ts
+++ b/apps/web/features/Home/FlightLog/flightLog.ts
@@ -1,15 +1,10 @@
+import {
+  DESTINATION_LABELS,
+  type DestinationCode,
+} from '~/features/Home/destination'
 import type { TimeLineItem } from '~/features/Home/ProjectTimeLIne/type'
 
-import type { DestinationCode, FlightLogEntry, FlightStatus } from './type'
-
-export const DESTINATION_LABELS: Record<DestinationCode, string> = {
-  LAW: '法律',
-  ACC: '会計',
-  EST: '住宅',
-  CAR: 'キャリア',
-  LIV: '配信',
-  GEN: 'その他',
-}
+import type { FlightLogEntry, FlightStatus } from './type'
 
 export const FALLBACK_DESTINATION: DestinationCode = 'GEN'
 
@@ -29,12 +24,16 @@ const DESTINATION_KEYWORDS: ReadonlyArray<{
   { code: 'LIV', keywords: ['配信', 'ライブ', 'ストリーミング'] },
 ]
 
-function resolveDestination(title: string): DestinationCode {
+function inferDestination(title: string): DestinationCode {
   const matched = DESTINATION_KEYWORDS.find(({ keywords }) =>
     keywords.some((keyword) => title.includes(keyword))
   )
 
   return matched?.code ?? FALLBACK_DESTINATION
+}
+
+function resolveDestination(project: TimeLineItem): DestinationCode {
+  return project.destination ?? inferDestination(project.title)
 }
 
 function resolveStartKey(period: string): string {
@@ -57,7 +56,7 @@ export function toFlightLog(
   projects: ReadonlyArray<TimeLineItem>
 ): Array<FlightLogEntry> {
   return [...projects].sort(compareByStartDescending).map((project, index) => {
-    const destination = resolveDestination(project.title)
+    const destination = resolveDestination(project)
 
     return {
       flightNo: `FL-${String(index + 1).padStart(3, '0')}`,

--- a/apps/web/features/Home/FlightLog/type.ts
+++ b/apps/web/features/Home/FlightLog/type.ts
@@ -1,13 +1,4 @@
-export const DESTINATION_CODES = [
-  'LAW',
-  'ACC',
-  'EST',
-  'CAR',
-  'LIV',
-  'GEN',
-] as const
-
-export type DestinationCode = (typeof DESTINATION_CODES)[number]
+import type { DestinationCode } from '~/features/Home/destination'
 
 export type FlightStatus = 'active' | 'completed'
 

--- a/apps/web/features/Home/HomeWrapper/components/HomeWrapper.tsx
+++ b/apps/web/features/Home/HomeWrapper/components/HomeWrapper.tsx
@@ -243,19 +243,21 @@ export function HomeWrapper() {
             <p className="label-mono text-ink-muted">PROFILE</p>
             <div className="text-ink-muted max-w-[68ch] space-y-6 leading-[1.9]">
               <p>
-                私は3年間のフロントエンド開発経験を持つエンジニアです。
-                React、TypeScript、Next.jsを中心としたモダンなWeb技術を駆使して、
-                ユーザーエクスペリエンスを最優先に考えた高品質なアプリケーションの開発に取り組んでいます。
+                2023年からフロントエンドを中心に7件の案件へ参画してきました。直近は法人向け
+                AI SaaS「Resme」で開発責任者として、画面実装から Terraform と
+                Google Cloud
+                でのインフラ構築、顧客の要件定義まで縦断して担当しました。
               </p>
               <p>
-                常に最新の技術トレンドをキャッチアップし、パフォーマンス最適化から
-                アクセシビリティまで、総合的な視点でプロダクト開発に貢献します。
+                Claude Code を中心とした AI
+                駆動開発を実務のフローに組み込み、自分は要件整理・設計・レビューに集中する進め方を確立しています。TDD
+                と型安全のルールを規約として明文化し、生成されたコードの品質を一定に保っています。
               </p>
             </div>
           </div>
         </Section>
 
-        <Section id="skills" title="SKILLS" subtitle="技術スタックと習熟度">
+        <Section id="skills" title="SKILLS" subtitle="技術スタックと経験年数">
           <SkillBadges />
         </Section>
 

--- a/apps/web/features/Home/ProjectTimeLIne/config.ts
+++ b/apps/web/features/Home/ProjectTimeLIne/config.ts
@@ -29,41 +29,95 @@ export const personalProjects: Array<TimeLineItem> = [
 
 export const clientProjects: Array<TimeLineItem> = [
   {
-    title: 'AIをもちいた、会計事務所の業務改善アプリケーション開発',
-    period: '2024.06 - 現在',
-    role: 'インターン',
+    title: 'Resme(レスミー)プロダクト開発',
+    period: '2025.08 - 2026.04',
+    role: 'フルスタックエンジニア(開発責任者)',
     skills: [
       'TypeScript',
       'Next.js(App Router)',
-      'shadcn-ui',
-      'Supabase',
-      'GCP',
-      'Clerk',
-      'Drizzle ORM',
+      'Google Cloud',
+      'Terraform',
+      'PostgreSQL',
+      'Figma',
     ],
     description:
-      'AIを用いた会計事務所の業務改善アプリケーション開発を行いました。',
+      'Gmail・カレンダー連携型の法人向け AI SaaS。再連携動線の整備、課金モデルのユーザー単位移行、議事録ボット等をフロントからインフラまで縦断して開発。顧客要件定義の窓口も担当。',
+    destination: 'CAR',
   },
   {
-    title: '社内勤怠管理ーサービス',
-    period: '2023.09 - 2023.12',
-    role: '業務委託',
-    skills: ['TypeScript', 'Next.js(App Router)', 'Firebase', 'Prisma'],
-    description: '業務委託先の会社様の勤怠管理アプリケーションを開発',
-  },
-  {
-    title: '決済アプリケーション管理サービスのフロントエンド開発',
-    period: '2023.03 - 2023.12',
-    role: '業務委託',
+    title: '弁護士事務所向け 債務整理業務改善サービス',
+    period: '2025.08 - 2025.12',
+    role: 'フロントエンドエンジニア',
     skills: [
       'TypeScript',
-      'Next.js(Page Router)',
-      'Ruby on Rails',
-      'GraphQL',
-      'Hasura',
-      'AWS',
+      'Next.js(App Router)',
+      'Hono',
+      'Google Cloud',
+      'Terraform',
+      'PostgreSQL',
     ],
     description:
-      'C to C 中小販売店の決済端末と決済アプリケーションの管理サービス開発',
+      '相談者向けアプリと事務所向け管理画面をフロントエンド一人称で担い 5ヶ月でリリース。Auth0 認証基盤、LINE 配信、CSV 一括インポートを実装。',
+  },
+  {
+    title: '会計事務所向け AI SaaS 開発',
+    period: '2024.06 - 2025.06',
+    role: 'フロントエンドエンジニア',
+    skills: [
+      'TypeScript',
+      'Next.js(App Router)',
+      'Supabase',
+      'Google Cloud',
+      'Figma',
+    ],
+    description:
+      '13ヶ月継続参画。画面遷移・エラーハンドリングの詳細設計から実装・テストまで一人称で担当し、UI/UX 改善提案を起点にユーザーの入力負荷を削減。',
+  },
+  {
+    title: 'toC 占いチャットボットアプリ開発',
+    period: '2023.12 - 2024.02',
+    role: 'フロントエンドエンジニア',
+    skills: ['TypeScript', 'Next.js(App Router)', 'Firebase', 'ChatGPT API'],
+    description:
+      'ChatGPT API を用いた対話機能を実装からテストまで担当し、3ヶ月でフロントエンドを実装完了。',
+    destination: 'GEN',
+  },
+  {
+    title: 'toC ライブ配信ストリーミングサービス',
+    period: '2023.12 - 2024.03',
+    role: 'フロントエンドエンジニア',
+    skills: [
+      'TypeScript',
+      'Next.js(Pages Router)',
+      'WebRTC',
+      'Firebase',
+      'Express',
+    ],
+    description:
+      'WebRTC を用いたリアルタイム配信画面を実装。Firebase でのデータ処理、UI/UX 改善、コードレビューまで担当。',
+  },
+  {
+    title: '社内勤怠管理ツール開発',
+    period: '2023.09 - 2023.12',
+    role: 'フロントエンドエンジニア',
+    skills: ['TypeScript', 'Next.js', 'Chakra UI', 'Firebase'],
+    description:
+      '立ち上げ期から参画し 4ヶ月で画面実装を完了。GitHub Issue でのチケット管理まで自走。',
+  },
+  {
+    title: 'POS アプリケーション管理サービス開発',
+    period: '2023.03 - 2024.03',
+    role: 'フロントエンドエンジニア',
+    skills: [
+      'TypeScript',
+      'Next.js(Pages Router)',
+      'GraphQL(Hasura)',
+      'AWS',
+      'MySQL',
+      'Mantine',
+    ],
+    description:
+      '13ヶ月継続参画。GraphQL でのデータ取得と UI 反映、react-hook-form + zod のフォーム構築、仕様整理まで担当。',
+    destination: 'GEN',
   },
 ]

--- a/apps/web/features/Home/ProjectTimeLIne/type.ts
+++ b/apps/web/features/Home/ProjectTimeLIne/type.ts
@@ -1,12 +1,19 @@
 import { z } from 'zod'
 
+import { DESTINATION_CODES } from '~/features/Home/destination'
+
 export const timeLineSchema = z.object({
   title: z.string(),
   description: z.string(),
   period: z.string(),
   url: z.string().optional(),
   position: z.enum(['フロントエンド開発', 'バックエンド開発', 'PM']).optional(),
-  role: z.enum(['個人開発', '業務委託', 'インターン']),
+  role: z.enum([
+    '個人開発',
+    'フロントエンドエンジニア',
+    'フルスタックエンジニア(開発責任者)',
+  ]),
   skills: z.array(z.string()),
+  destination: z.enum(DESTINATION_CODES).optional(),
 })
 export type TimeLineItem = z.infer<typeof timeLineSchema>

--- a/apps/web/features/Home/SkillBadges/components/SkillBadges.tsx
+++ b/apps/web/features/Home/SkillBadges/components/SkillBadges.tsx
@@ -2,40 +2,51 @@
 
 import { motion, useReducedMotion } from 'framer-motion'
 
+import {
+  clientProjects,
+  personalProjects,
+} from '~/features/Home/ProjectTimeLIne/config'
+
 type SkillType = {
   name: string
   category: string
-  level: number
+  minYears: number | null
+  maxYears: number
 }
 
 const EASE = [0.22, 1, 0.36, 1] as const
 
 const SKILLS: ReadonlyArray<SkillType> = [
-  { name: 'React', category: 'Frontend', level: 95 },
-  { name: 'TypeScript', category: 'Language', level: 90 },
-  { name: 'Next.js', category: 'Framework', level: 88 },
-  { name: 'Tailwind CSS', category: 'Styling', level: 92 },
-  { name: 'Node.js', category: 'Backend', level: 80 },
-  { name: 'Supabase', category: 'Database', level: 85 },
-  { name: 'Firebase', category: 'Backend', level: 75 },
-  { name: 'React Native', category: 'Mobile', level: 70 },
-  { name: 'Hono', category: 'Framework', level: 75 },
-  { name: 'NestJS', category: 'Backend', level: 78 },
+  { name: 'TypeScript', category: 'Language', minYears: 3, maxYears: 5 },
+  { name: 'JavaScript', category: 'Language', minYears: 3, maxYears: 5 },
+  { name: 'Next.js', category: 'Framework', minYears: 3, maxYears: 5 },
+  { name: 'Figma', category: 'Design', minYears: 2, maxYears: 3 },
+  { name: 'Google Cloud', category: 'Infra', minYears: 2, maxYears: 3 },
+  { name: 'PostgreSQL', category: 'Database', minYears: 2, maxYears: 3 },
+  { name: 'GraphQL', category: 'API', minYears: null, maxYears: 1 },
+  { name: 'Ruby', category: 'Language', minYears: null, maxYears: 1 },
 ]
 
-const AVERAGE_LEVEL = Math.round(
-  SKILLS.reduce((total, skill) => total + skill.level, 0) / SKILLS.length
-)
+const LONGEST_YEARS = Math.max(...SKILLS.map((skill) => skill.maxYears))
 
 const SUMMARY: ReadonlyArray<{ value: string; label: string }> = [
   { value: String(SKILLS.length), label: 'TECHNOLOGIES' },
-  { value: '3+', label: 'YEARS' },
-  { value: `${AVERAGE_LEVEL}%`, label: 'AVG LEVEL' },
-  { value: '10+', label: 'PROJECTS' },
+  { value: String(clientProjects.length), label: 'CLIENT PROJECTS' },
+  { value: String(personalProjects.length), label: 'PERSONAL PROJECTS' },
+  { value: '3年+', label: 'EXPERIENCE' },
 ]
+
+function toYearsLabel(skill: SkillType): string {
+  if (skill.minYears === null) {
+    return `〜${skill.maxYears}年`
+  }
+
+  return `${skill.minYears}〜${skill.maxYears}年`
+}
 
 function SkillRow({ skill, index }: { skill: SkillType; index: number }) {
   const shouldReduceMotion = useReducedMotion()
+  const ratio = skill.maxYears / LONGEST_YEARS
 
   return (
     <li className="border-hairline flex items-center gap-4 border-b py-4">
@@ -48,8 +59,8 @@ function SkillRow({ skill, index }: { skill: SkillType; index: number }) {
       <span className="bg-hairline relative h-px flex-1">
         <motion.span
           className="bg-navy absolute inset-y-0 left-0 block origin-left"
-          initial={{ scaleX: shouldReduceMotion ? skill.level / 100 : 0 }}
-          whileInView={{ scaleX: skill.level / 100 }}
+          initial={{ scaleX: shouldReduceMotion ? ratio : 0 }}
+          whileInView={{ scaleX: ratio }}
           viewport={{ once: true }}
           transition={{
             duration: shouldReduceMotion ? 0 : 0.42,
@@ -59,8 +70,8 @@ function SkillRow({ skill, index }: { skill: SkillType; index: number }) {
           style={{ width: '100%' }}
         />
       </span>
-      <span className="text-ink-muted w-[3rem] shrink-0 text-right font-mono text-xs">
-        {skill.level}
+      <span className="text-ink w-[4.5rem] shrink-0 text-right font-mono text-xs">
+        {toYearsLabel(skill)}
       </span>
     </li>
   )

--- a/apps/web/features/Home/destination.ts
+++ b/apps/web/features/Home/destination.ts
@@ -1,0 +1,19 @@
+export const DESTINATION_CODES = [
+  'LAW',
+  'ACC',
+  'EST',
+  'CAR',
+  'LIV',
+  'GEN',
+] as const
+
+export type DestinationCode = (typeof DESTINATION_CODES)[number]
+
+export const DESTINATION_LABELS: Record<DestinationCode, string> = {
+  LAW: '法律',
+  ACC: '会計',
+  EST: '住宅',
+  CAR: 'キャリア',
+  LIV: '配信',
+  GEN: 'その他',
+}


### PR DESCRIPTION
## 概要
最新の職務経歴書に基づいてポートフォリオのデータを更新。

- clientProjects を実案件 7 件に全面差し替え(Resme/弁護士/会計/占い/配信/勤怠/POS)
- TimeLineItem に destination 明示指定を追加(テスト先行、キーワード推論フォールバック)
- SKILLS を架空の習熟度%から経験年数ベースに変更、統計タイルも実データ導出に
- ABOUT を事実ベースの 2 段落に書き換え

## テスト
- vitest 36件パス / tsc クリーン / 変更ファイルの biome 診断ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsD3s1MsSf4w3bgGaeYN2N