### PR TITLE
feat(web): FLIGHT LOG に案件詳細のインライン展開を追加

### DIFF
--- a/apps/web/features/Home/FlightLog/components/FlightLog.tsx
+++ b/apps/web/features/Home/FlightLog/components/FlightLog.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { motion, useReducedMotion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { useState } from 'react'
+
 import {
   clientProjects,
   personalProjects,
@@ -11,6 +13,12 @@ import { toFlightLog } from '../flightLog'
 import type { FlightLogEntry } from '../type'
 
 const ENTRIES = toFlightLog([...clientProjects, ...personalProjects])
+
+const EASE = [0.22, 1, 0.36, 1] as const
+const PANEL_DURATION = 0.42
+
+const ROW_GRID =
+  'grid items-center gap-x-4 grid-cols-[6rem_3.5rem_minmax(0,1fr)_5rem_6.5rem_1rem] lg:grid-cols-[7rem_4rem_minmax(0,1fr)_5.5rem_minmax(0,9rem)_7rem_1rem]'
 
 function StatusCell({ status }: { status: FlightLogEntry['status'] }) {
   if (status === 'active') {
@@ -71,8 +79,262 @@ function PlaneMark({ className }: { className?: string }) {
   )
 }
 
-export function FlightLog() {
+function ToggleArrow({ isOpen }: { isOpen: boolean }) {
   const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.span
+      className="text-navy inline-flex justify-self-end"
+      animate={{ rotate: isOpen ? 180 : 0 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.18, ease: EASE }}
+    >
+      <svg viewBox="0 0 12 8" className="w-3" aria-hidden="true">
+        <path
+          d="M 1 1.5 L 6 6.5 L 11 1.5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </motion.span>
+  )
+}
+
+function ActionList({ actions }: { actions: ReadonlyArray<string> }) {
+  return (
+    <ol className="space-y-2">
+      {actions.map((action, index) => (
+        <li key={action} className="flex gap-3">
+          <span className="text-navy shrink-0 font-mono text-xs leading-[1.9] tracking-[0.12em]">
+            {String(index + 1).padStart(2, '0')}
+          </span>
+          <span>{action}</span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function DetailField({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-hairline grid gap-1 border-t py-4 first:border-t-0 md:grid-cols-[7rem_minmax(0,1fr)] md:gap-6">
+      <dt className="label-mono text-ink-muted pt-1.5">{label}</dt>
+      <dd className="text-ink-muted text-sm leading-[1.9]">{children}</dd>
+    </div>
+  )
+}
+
+function StackList({ skills }: { skills: ReadonlyArray<string> }) {
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {skills.map((skill) => (
+        <li
+          key={skill}
+          className="border-hairline text-ink rounded-flat border px-2 py-1 font-mono text-xs"
+        >
+          {skill}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function FlightDetail({ entry }: { entry: FlightLogEntry }) {
+  const details = entry.details
+
+  return (
+    <dl className="bg-surface border-hairline border-t px-4 py-2 md:px-6">
+      <DetailField label="期間">{entry.period}</DetailField>
+      <DetailField label="役割">{entry.role}</DetailField>
+
+      {details?.structure ? (
+        <DetailField label="体制">{details.structure}</DetailField>
+      ) : null}
+
+      {details?.challenge ? (
+        <DetailField label="課題">{details.challenge}</DetailField>
+      ) : null}
+
+      {details?.actions ? (
+        <DetailField label="取り組み">
+          <ActionList actions={details.actions} />
+        </DetailField>
+      ) : null}
+
+      {details?.outcome ? (
+        <DetailField label="成果">{details.outcome}</DetailField>
+      ) : null}
+
+      {details ? null : (
+        <DetailField label="概要">{entry.description}</DetailField>
+      )}
+
+      <DetailField label="STACK">
+        <StackList skills={entry.skills} />
+      </DetailField>
+
+      {entry.url ? (
+        <DetailField label="LINK">
+          <a
+            href={entry.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-navy hover:underline"
+          >
+            {entry.url}
+          </a>
+        </DetailField>
+      ) : null}
+    </dl>
+  )
+}
+
+function DetailPanel({
+  entry,
+  isOpen,
+  panelId,
+}: {
+  entry: FlightLogEntry
+  isOpen: boolean
+  panelId: string
+}) {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <AnimatePresence initial={false}>
+      {isOpen ? (
+        <motion.div
+          key={panelId}
+          id={panelId}
+          className="overflow-hidden"
+          initial={{ height: 0 }}
+          animate={{ height: 'auto' }}
+          exit={{ height: 0 }}
+          transition={{
+            duration: shouldReduceMotion ? 0 : PANEL_DURATION,
+            ease: EASE,
+          }}
+        >
+          <FlightDetail entry={entry} />
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
+type FlightRowProps = {
+  entry: FlightLogEntry
+  index: number
+  isOpen: boolean
+  panelId: string
+  onToggle: () => void
+}
+
+function FlightRow({
+  entry,
+  index,
+  isOpen,
+  panelId,
+  onToggle,
+}: FlightRowProps) {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.li
+      className="border-hairline border-b"
+      initial={{
+        opacity: shouldReduceMotion ? 1 : 0.9,
+        y: shouldReduceMotion ? 0 : 6,
+      }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-40px' }}
+      transition={{
+        duration: shouldReduceMotion ? 0 : PANEL_DURATION,
+        delay: shouldReduceMotion ? 0 : index * 0.05,
+        ease: EASE,
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className={`${ROW_GRID} hover:bg-surface w-full cursor-pointer py-6 text-left transition-colors duration-[180ms]`}
+      >
+        <span className="text-ink font-mono text-sm tracking-[0.12em]">
+          {entry.flightNo}
+        </span>
+        <span className="text-ink font-mono text-sm">{entry.year}</span>
+        <span className="text-ink">{entry.project}</span>
+        <span>
+          <DestinationChip code={entry.destination} />
+        </span>
+        <span className="hidden lg:block">
+          <RouteArrow />
+        </span>
+        <span className="text-right">
+          <StatusCell status={entry.status} />
+        </span>
+        <ToggleArrow isOpen={isOpen} />
+      </button>
+
+      <DetailPanel entry={entry} isOpen={isOpen} panelId={panelId} />
+    </motion.li>
+  )
+}
+
+function FlightCard({ entry, isOpen, panelId, onToggle }: FlightRowProps) {
+  return (
+    <li className="border-hairline border-b">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className="w-full cursor-pointer py-6 text-left"
+      >
+        <span className="flex items-center justify-between gap-4">
+          <span className="text-ink font-mono text-sm tracking-[0.12em]">
+            {entry.flightNo}
+          </span>
+          <span className="flex items-center gap-3">
+            <StatusCell status={entry.status} />
+            <ToggleArrow isOpen={isOpen} />
+          </span>
+        </span>
+        <span className="text-ink mt-2 block">{entry.project}</span>
+        <span className="mt-2 flex items-center gap-4">
+          <span className="text-ink-muted font-mono text-sm">{entry.year}</span>
+          <DestinationChip code={entry.destination} />
+          <span className="text-ink-muted text-sm">
+            {entry.destinationLabel}
+          </span>
+        </span>
+      </button>
+
+      <DetailPanel entry={entry} isOpen={isOpen} panelId={panelId} />
+    </li>
+  )
+}
+
+export function FlightLog() {
+  const [openFlights, setOpenFlights] = useState<ReadonlyArray<string>>([])
+
+  const toggleFlight = (flightNo: string) => {
+    setOpenFlights((current) =>
+      current.includes(flightNo)
+        ? current.filter((item) => item !== flightNo)
+        : [...current, flightNo]
+    )
+  }
 
   return (
     <div>
@@ -81,95 +343,53 @@ export function FlightLog() {
           <PlaneMark className="text-navy size-6 shrink-0 translate-y-[2px]" />
           FLIGHT LOG
         </h2>
-        <p className="text-ink-muted text-sm">プロジェクトフライトログ</p>
+        <p className="text-ink-muted text-sm">
+          プロジェクトフライトログ(行を選ぶと詳細が開きます)
+        </p>
         <p className="label-mono text-ink-muted ml-auto hidden md:block">
           {ENTRIES.length} FLIGHTS
         </p>
       </div>
 
       <div className="border-hairline mt-8 hidden border-t md:block">
-        <table className="w-full border-collapse text-left">
-          <thead>
-            <tr className="border-hairline border-b">
-              <th className="label-mono text-ink-muted py-4 pr-4 font-normal">
-                FLIGHT NO.
-              </th>
-              <th className="label-mono text-ink-muted py-4 pr-4 font-normal">
-                YEAR
-              </th>
-              <th className="label-mono text-ink-muted py-4 pr-4 font-normal">
-                PROJECT
-              </th>
-              <th className="label-mono text-ink-muted py-4 pr-4 font-normal">
-                DESTINATION
-              </th>
-              <th className="py-4 pr-4">
-                <span className="sr-only">路線</span>
-              </th>
-              <th className="label-mono text-ink-muted py-4 text-right font-normal">
-                STATUS
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {ENTRIES.map((entry, index) => (
-              <motion.tr
-                key={entry.flightNo}
-                initial={{
-                  opacity: shouldReduceMotion ? 1 : 0.9,
-                  y: shouldReduceMotion ? 0 : 6,
-                }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: '-40px' }}
-                transition={{
-                  duration: shouldReduceMotion ? 0 : 0.42,
-                  delay: shouldReduceMotion ? 0 : index * 0.05,
-                  ease: [0.22, 1, 0.36, 1],
-                }}
-                className="border-hairline hover:bg-surface border-b transition-colors"
-              >
-                <td className="text-ink font-mono py-6 pr-4 text-sm tracking-[0.12em]">
-                  {entry.flightNo}
-                </td>
-                <td className="text-ink font-mono py-6 pr-4 text-sm">
-                  {entry.year}
-                </td>
-                <td className="text-ink py-6 pr-4">{entry.project}</td>
-                <td className="py-6 pr-4">
-                  <DestinationChip code={entry.destination} />
-                </td>
-                <td className="py-6 pr-4">
-                  <RouteArrow />
-                </td>
-                <td className="py-6 text-right">
-                  <StatusCell status={entry.status} />
-                </td>
-              </motion.tr>
-            ))}
-          </tbody>
-        </table>
+        <div
+          className={`${ROW_GRID} border-hairline text-ink-muted border-b py-4`}
+        >
+          <span className="label-mono">FLIGHT NO.</span>
+          <span className="label-mono">YEAR</span>
+          <span className="label-mono">PROJECT</span>
+          <span className="label-mono">DESTINATION</span>
+          <span className="hidden lg:block">
+            <span className="sr-only">路線</span>
+          </span>
+          <span className="label-mono text-right">STATUS</span>
+          <span />
+        </div>
+
+        <ul>
+          {ENTRIES.map((entry, index) => (
+            <FlightRow
+              key={entry.flightNo}
+              entry={entry}
+              index={index}
+              isOpen={openFlights.includes(entry.flightNo)}
+              panelId={`flight-detail-row-${entry.flightNo}`}
+              onToggle={() => toggleFlight(entry.flightNo)}
+            />
+          ))}
+        </ul>
       </div>
 
       <ul className="border-hairline mt-6 border-t md:hidden">
-        {ENTRIES.map((entry) => (
-          <li key={entry.flightNo} className="border-hairline border-b py-6">
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-ink font-mono text-sm tracking-[0.12em]">
-                {entry.flightNo}
-              </span>
-              <StatusCell status={entry.status} />
-            </div>
-            <p className="text-ink mt-2">{entry.project}</p>
-            <div className="mt-2 flex items-center gap-4">
-              <span className="text-ink-muted font-mono text-sm">
-                {entry.year}
-              </span>
-              <DestinationChip code={entry.destination} />
-              <span className="text-ink-muted text-sm">
-                {entry.destinationLabel}
-              </span>
-            </div>
-          </li>
+        {ENTRIES.map((entry, index) => (
+          <FlightCard
+            key={entry.flightNo}
+            entry={entry}
+            index={index}
+            isOpen={openFlights.includes(entry.flightNo)}
+            panelId={`flight-detail-card-${entry.flightNo}`}
+            onToggle={() => toggleFlight(entry.flightNo)}
+          />
         ))}
       </ul>
     </div>

--- a/apps/web/features/Home/FlightLog/flightLog.test.ts
+++ b/apps/web/features/Home/FlightLog/flightLog.test.ts
@@ -227,6 +227,84 @@ describe('toFlightLog', () => {
     expect(entry?.year).toBe('----')
   })
 
+  it('carries the detail fields of a client project through untouched', () => {
+    // #given
+    const details = {
+      structure: '10人未満 / リモートメイン',
+      challenge: '外部サービスへの依存が多い状態。',
+      actions: ['再連携の動線を実装', '課金モデルを移行'],
+      outcome: 'フロントからインフラまで縦断して届ける体制を構築。',
+    }
+
+    // #when
+    const [entry] = toFlightLog([
+      {
+        title: 'Resme(レスミー)プロダクト開発',
+        description: '法人向け AI SaaS。',
+        period: '2025.08 - 2026.04',
+        role: 'フルスタックエンジニア(開発責任者)',
+        skills: ['TypeScript', 'Terraform'],
+        destination: 'CAR',
+        details,
+      },
+    ])
+
+    // #then
+    expect(entry).toMatchObject({
+      period: '2025.08 - 2026.04',
+      role: 'フルスタックエンジニア(開発責任者)',
+      description: '法人向け AI SaaS。',
+      skills: ['TypeScript', 'Terraform'],
+      details,
+    })
+  })
+
+  it('carries the external url of a personal project through untouched', () => {
+    // #given
+    const url = 'https://nacky.me/home'
+
+    // #when
+    const [entry] = toFlightLog([
+      {
+        title: 'ポートフォリオサイト',
+        description: '個人ポートフォリオサイト。',
+        period: '2024.11 - 現在',
+        role: '個人開発',
+        skills: ['TypeScript'],
+        url,
+      },
+    ])
+
+    // #then
+    expect(entry?.url).toBe(url)
+  })
+
+  it('leaves details undefined for a project without them', () => {
+    // #when
+    const [entry] = toFlightLog([
+      {
+        title: 'coffee drip Recipe app coffeerepi',
+        description: 'Dripレシピを管理できるアプリケーション',
+        period: '2023.09 - 2023.11',
+        role: '個人開発',
+        skills: ['TypeScript'],
+      },
+    ])
+
+    // #then
+    expect(entry?.details).toBeUndefined()
+  })
+
+  it('keeps the detail fields of every real client project', () => {
+    // #when
+    const entries = toFlightLog(clientProjects)
+
+    // #then
+    expect(
+      entries.every((entry) => (entry.details?.actions?.length ?? 0) >= 3)
+    ).toBe(true)
+  })
+
   it('returns an empty log for an empty project list', () => {
     expect(toFlightLog([])).toEqual([])
   })

--- a/apps/web/features/Home/FlightLog/flightLog.ts
+++ b/apps/web/features/Home/FlightLog/flightLog.ts
@@ -65,6 +65,11 @@ export function toFlightLog(
       destination,
       destinationLabel: DESTINATION_LABELS[destination],
       status: resolveStatus(project.period),
+      period: project.period,
+      role: project.role,
+      description: project.description,
+      skills: project.skills,
+      details: project.details,
       url: project.url,
     }
   })

--- a/apps/web/features/Home/FlightLog/type.ts
+++ b/apps/web/features/Home/FlightLog/type.ts
@@ -1,4 +1,5 @@
 import type { DestinationCode } from '~/features/Home/destination'
+import type { ProjectDetail } from '~/features/Home/ProjectTimeLIne/type'
 
 export type FlightStatus = 'active' | 'completed'
 
@@ -9,5 +10,10 @@ export type FlightLogEntry = {
   destination: DestinationCode
   destinationLabel: string
   status: FlightStatus
+  period: string
+  role: string
+  description: string
+  skills: ReadonlyArray<string>
+  details?: ProjectDetail
   url?: string
 }

--- a/apps/web/features/Home/ProjectTimeLIne/config.ts
+++ b/apps/web/features/Home/ProjectTimeLIne/config.ts
@@ -43,6 +43,19 @@ export const clientProjects: Array<TimeLineItem> = [
     description:
       'Gmail・カレンダー連携型の法人向け AI SaaS。再連携動線の整備、課金モデルのユーザー単位移行、議事録ボット等をフロントからインフラまで縦断して開発。顧客要件定義の窓口も担当。',
     destination: 'CAR',
+    details: {
+      structure: '10人未満 / リモートメイン',
+      challenge:
+        '外部サービスへの依存が多く、連携が切れるとユーザーが自力で復旧できない状態。課金の仕組みが実際の売り方と噛み合っていなかった。',
+      actions: [
+        '権限切れ・トークン失効を検知し再連携へ導く動線を Web・Chrome 拡張・通知メールに実装',
+        '課金モデルを組織単位からユーザー単位へ移行(フロント〜決済連携〜DB)',
+        'メール返信下書き生成・カスタムプロンプト・議事録ボット・カレンダー同期機能を開発',
+        '社内管理画面の新規立ち上げ、インフラの Terraform 化、CI・QA 整備',
+      ],
+      outcome:
+        '一人でフロントからインフラまで縦断して機能を届ける体制を構築。連携断からの自力復旧を可能にし、無料プラン・トライアル・法人契約を同一基盤で扱えるようにした。顧客要件定義の窓口も担当。',
+    },
   },
   {
     title: '弁護士事務所向け 債務整理業務改善サービス',
@@ -58,6 +71,19 @@ export const clientProjects: Array<TimeLineItem> = [
     ],
     description:
       '相談者向けアプリと事務所向け管理画面をフロントエンド一人称で担い 5ヶ月でリリース。Auth0 認証基盤、LINE 配信、CSV 一括インポートを実装。',
+    details: {
+      structure: '10人未満 / リモートメイン',
+      challenge:
+        '連絡・書類・債権者との交渉状況の管理が事務所の手作業に依存。相談者側も次に何をすべきか分かりにくい状態だった。',
+      actions: [
+        '相談者向けアプリに案件チャットと次の手続きを示すステップ UI、下書きの確認〜送信フローを実装',
+        '事務所向け管理画面に案件・交渉相手・メンバー管理、CSV 一括インポート、LINE 配信メッセージの作成・送信を実装',
+        'Auth0 による認証基盤(パスワードリセット・権限制御)を構築',
+        'Hono での API 追加・バグ改善、Terraform でのステージング環境構築、E2E・ユニットテスト',
+      ],
+      outcome:
+        '相談者・事務所の双方の画面をフロントエンド一人称で担い、5ヶ月でリリース。手作業だった案件管理と連絡を画面上で完結できるようにした。',
+    },
   },
   {
     title: '会計事務所向け AI SaaS 開発',
@@ -72,6 +98,19 @@ export const clientProjects: Array<TimeLineItem> = [
     ],
     description:
       '13ヶ月継続参画。画面遷移・エラーハンドリングの詳細設計から実装・テストまで一人称で担当し、UI/UX 改善提案を起点にユーザーの入力負荷を削減。',
+    details: {
+      structure: '10人未満 / リモートメイン',
+      challenge:
+        '会計業務は入力項目・確認事項が多く、画面が複雑になりやすい。専門知識のないユーザーでも迷わず進められる UI に落とし込む必要があった。',
+      actions: [
+        '画面遷移・エラーハンドリングの詳細設計を担当しチケット単位で機能開発を推進',
+        'Figma を基に新規ページを実装、Server Action によるデータ処理と Supabase のデータ取得を担当',
+        'Supabase SDK / Clerk による認証・データ連携',
+        '入力フォームのステップ削減、一覧へのフィルタ・検索追加、エラー文言の改善を継続的に提案・実装',
+      ],
+      outcome:
+        '13ヶ月にわたり継続参画し、設計から実装・テストまでを一人称で担当。UI/UX の改善提案を起点にした開発で、ユーザーの入力負荷を下げた。',
+    },
   },
   {
     title: 'toC 占いチャットボットアプリ開発',
@@ -81,6 +120,18 @@ export const clientProjects: Array<TimeLineItem> = [
     description:
       'ChatGPT API を用いた対話機能を実装からテストまで担当し、3ヶ月でフロントエンドを実装完了。',
     destination: 'GEN',
+    details: {
+      structure: '10人未満 / フルリモート',
+      challenge:
+        'ChatGPT API を用いた対話機能という当時まだ知見の少ない領域を、短期間で立ち上げる必要があった。',
+      actions: [
+        'Figma を参照して Next.js(App Router)でページレイアウトを作成・修正しユニットテストまで実施',
+        'ChatGPT API を用いたチャット機能の実装とテスト',
+        'GitHub Issue でチケットを自ら作成・管理し 5 名チームの開発を進行',
+      ],
+      outcome:
+        '3ヶ月で toC 向けチャットボットアプリのフロントエンドを実装完了。生成 AI API を扱う新規領域に主体的に取り組んだ。',
+    },
   },
   {
     title: 'toC ライブ配信ストリーミングサービス',
@@ -95,6 +146,19 @@ export const clientProjects: Array<TimeLineItem> = [
     ],
     description:
       'WebRTC を用いたリアルタイム配信画面を実装。Firebase でのデータ処理、UI/UX 改善、コードレビューまで担当。',
+    details: {
+      structure: '10人未満 / フルリモート',
+      challenge:
+        'WebRTC を用いたリアルタイム配信画面という難度の高い実装に加え、ユーザーが直接触れるサービスとして UI/UX の継続的な改善が必要だった。',
+      actions: [
+        'Figma を参照して画面・コンポーネントを実装し UI/UX 改善を継続',
+        'WebRTC を用いた配信画面を実装',
+        'Firebase でのデータ処理',
+        '実装・修正・ユニットテストとコードレビュー',
+      ],
+      outcome:
+        '4ヶ月でリアルタイム配信画面を含むフロントエンドを実装。低レイヤ寄りの新規領域に取り組みつつ UI/UX 改善まで担当した。',
+    },
   },
   {
     title: '社内勤怠管理ツール開発',
@@ -103,6 +167,18 @@ export const clientProjects: Array<TimeLineItem> = [
     skills: ['TypeScript', 'Next.js', 'Chakra UI', 'Firebase'],
     description:
       '立ち上げ期から参画し 4ヶ月で画面実装を完了。GitHub Issue でのチケット管理まで自走。',
+    details: {
+      structure: '10人未満 / フルリモート',
+      challenge:
+        '初期フェーズのため画面仕様もタスクも未整備。3 名の少人数チームで設計から実装・テストまで進める体制づくりが求められた。',
+      actions: [
+        'Figma を参照して Next.js + Chakra UI で画面を構築',
+        'Firebase(Firestore)からのデータ取得を実装',
+        'GitHub Issue でチケットを自ら作成・管理して進行を可視化',
+      ],
+      outcome:
+        '立ち上げ期から 4ヶ月で勤怠管理アプリの画面実装を完了。実装者としてだけでなく進行管理の一部も担った。',
+    },
   },
   {
     title: 'POS アプリケーション管理サービス開発',
@@ -119,5 +195,19 @@ export const clientProjects: Array<TimeLineItem> = [
     description:
       '13ヶ月継続参画。GraphQL でのデータ取得と UI 反映、react-hook-form + zod のフォーム構築、仕様整理まで担当。',
     destination: 'GEN',
+    details: {
+      structure: '10〜50人未満 / フルリモート',
+      challenge:
+        'クライアント要望が未整理のままタスク化する必要があった。GraphQL 経由のデータの UI 反映と、項目数の多い管理画面フォームの実装・品質担保が求められた。',
+      actions: [
+        'Backlog でタスク作成・編集まで実施',
+        'GraphQL(Hasura)でのデータ取得と UI 反映',
+        'Mantine による画面実装・改善',
+        'react-hook-form + zod でのフォーム構築',
+        'ステージング環境で単体テスト・パフォーマンステスト',
+      ],
+      outcome:
+        'フロントエンド開発支援として長期継続で参画。要件ヒアリングから UI 実装・テストまでを一貫して担当し、仕様整理の役割も任された。',
+    },
   },
 ]

--- a/apps/web/features/Home/ProjectTimeLIne/type.ts
+++ b/apps/web/features/Home/ProjectTimeLIne/type.ts
@@ -2,6 +2,14 @@ import { z } from 'zod'
 
 import { DESTINATION_CODES } from '~/features/Home/destination'
 
+export const projectDetailSchema = z.object({
+  structure: z.string().optional(),
+  challenge: z.string().optional(),
+  actions: z.array(z.string()).readonly().optional(),
+  outcome: z.string().optional(),
+})
+export type ProjectDetail = z.infer<typeof projectDetailSchema>
+
 export const timeLineSchema = z.object({
   title: z.string(),
   description: z.string(),
@@ -15,5 +23,6 @@ export const timeLineSchema = z.object({
   ]),
   skills: z.array(z.string()),
   destination: z.enum(DESTINATION_CODES).optional(),
+  details: projectDetailSchema.optional(),
 })
 export type TimeLineItem = z.infer<typeof timeLineSchema>


### PR DESCRIPTION
## 概要
FLIGHT LOG の行クリックで案件詳細(課題・取り組み・成果・STACK)をインライン展開できるように。

- テーブルをグリッドの disclosure リストに変更(native button + aria-expanded、キーボード操作可)
- AnimatePresence の height アニメーション、reduced-motion で即時切替
- 経歴書の課題・取り組み・成果を details として全 7 案件に転記
- 個人開発 2 件は概要 + 外部リンクのシンプル構成

## テスト
- vitest 40件パス / tsc クリーン / 変更ファイルの biome 診断ゼロ
- デスクトップ/モバイル/キーボード操作をヘッドレスブラウザで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsD3s1MsSf4w3bgGaeYN2N