### PR TITLE
feat(web): resume ダウンロードURLを不透明トークン形式に変更

### DIFF
--- a/apps/web/actions/resume/issueDownloadUrl/index.ts
+++ b/apps/web/actions/resume/issueDownloadUrl/index.ts
@@ -7,7 +7,7 @@ import { schema } from '~/actions/resume/issueDownloadUrl/schema'
 import { createSafeAction } from '~/lib/create-safe-action'
 import { hasValidAdminSession } from '~/lib/resume/admin-session'
 import { getRequiredResumeEnv } from '~/lib/resume/env'
-import { createResumeToken } from '~/lib/resume/token'
+import { createResumeToken, encodeResumeToken } from '~/lib/resume/token'
 
 function getRequestOrigin(headerStore: Headers) {
   const host = headerStore.get('host')
@@ -36,11 +36,7 @@ export async function handler(input: z.infer<typeof schema>) {
   )
   const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
   const token = createResumeToken({ ids: input.ids, expiresAt }, secret)
-  const searchParams = new URLSearchParams({
-    ids: token.ids.join(','),
-    exp: String(token.exp),
-    sig: token.sig,
-  })
+  const searchParams = new URLSearchParams({ t: encodeResumeToken(token) })
   const headerStore = await headers()
   const origin = getRequestOrigin(headerStore)
 

--- a/apps/web/actions/resume/requestDownloadUrl/index.ts
+++ b/apps/web/actions/resume/requestDownloadUrl/index.ts
@@ -6,7 +6,7 @@ import { schema } from '~/actions/resume/requestDownloadUrl/schema'
 import { createSafeAction } from '~/lib/create-safe-action'
 import { getRequiredResumeEnv } from '~/lib/resume/env'
 import { verifyPassword } from '~/lib/resume/password'
-import { createResumeToken } from '~/lib/resume/token'
+import { createResumeToken, encodeResumeToken } from '~/lib/resume/token'
 
 export async function handler(input: z.infer<typeof schema>) {
   const expectedPassword = getRequiredResumeEnv('RESUME_PASSWORD')
@@ -18,11 +18,7 @@ export async function handler(input: z.infer<typeof schema>) {
   const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
   const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
   const token = createResumeToken({ ids: input.ids, expiresAt }, secret)
-  const searchParams = new URLSearchParams({
-    ids: token.ids.join(','),
-    exp: String(token.exp),
-    sig: token.sig,
-  })
+  const searchParams = new URLSearchParams({ t: encodeResumeToken(token) })
 
   return { data: { url: `/api/resume/download?${searchParams}` } }
 }

--- a/apps/web/app/api/resume/download/route.ts
+++ b/apps/web/app/api/resume/download/route.ts
@@ -3,7 +3,11 @@ import { zipSync } from 'fflate'
 
 import { getRequiredResumeEnv } from '~/lib/resume/env'
 import { buildBundleFilename, buildResumeFilename } from '~/lib/resume/filename'
-import { isResumeFileId, verifyResumeToken } from '~/lib/resume/token'
+import {
+  decodeResumeToken,
+  isResumeFileId,
+  verifyResumeToken,
+} from '~/lib/resume/token'
 import type { ResumeFileId } from '~/lib/resume/token.types'
 
 export const runtime = 'nodejs'
@@ -82,21 +86,38 @@ async function createZipResponse(ids: ResumeFileId[], downloadedAt: Date) {
 
 export async function GET(request: Request) {
   const searchParams = new URL(request.url).searchParams
-  const idsParameter = searchParams.get('ids')
-  const ids = idsParameter?.split(',') ?? []
-  const exp = searchParams.get('exp') ?? ''
-  const sig = searchParams.get('sig') ?? ''
+  const encodedToken = searchParams.get('t')
+  let token: { ids: string[]; exp: string; sig: string }
 
-  if (
-    ids.length === 0 ||
-    ids.some((resumeFileId) => !isResumeFileId(resumeFileId))
-  ) {
-    return jsonError('書類の指定が不正です', 400)
+  if (encodedToken !== null) {
+    const decodedToken = decodeResumeToken(encodedToken)
+
+    if (!decodedToken) {
+      return jsonError('ダウンロードURLが無効です', 403)
+    }
+
+    token = decodedToken
+  } else {
+    const idsParameter = searchParams.get('ids')
+    const ids = idsParameter?.split(',') ?? []
+
+    if (
+      ids.length === 0 ||
+      ids.some((resumeFileId) => !isResumeFileId(resumeFileId))
+    ) {
+      return jsonError('書類の指定が不正です', 400)
+    }
+
+    token = {
+      ids,
+      exp: searchParams.get('exp') ?? '',
+      sig: searchParams.get('sig') ?? '',
+    }
   }
 
   try {
     const secret = getRequiredResumeEnv('RESUME_SIGNING_SECRET')
-    const tokenResult = verifyResumeToken({ ids, exp, sig }, secret, new Date())
+    const tokenResult = verifyResumeToken(token, secret, new Date())
 
     if (!tokenResult.ok) {
       return tokenResult.reason === 'expired'

--- a/apps/web/lib/resume/token.test.ts
+++ b/apps/web/lib/resume/token.test.ts
@@ -2,15 +2,106 @@ import { describe, expect, it } from 'vitest'
 
 import {
   createResumeToken,
+  decodeResumeToken,
+  encodeResumeToken,
   isResumeFileId,
   verifyResumeToken,
 } from '~/lib/resume/token'
+import type { ResumeFileId } from '~/lib/resume/token.types'
 
 const SECRET = 'test-signing-secret'
 const CREATED_AT = new Date('2026-07-13T00:00:00.000Z')
 const EXPIRES_AT = new Date('2026-07-13T00:05:00.000Z')
+const ENCODE_CASES: { name: string; ids: ResumeFileId[] }[] = [
+  { name: 'one file', ids: ['rirekisho-pdf'] },
+  {
+    name: 'multiple files',
+    ids: ['rirekisho-pdf', 'shokumu-keirekisho-pdf'],
+  },
+]
 
 describe('resume token', () => {
+  it.each(ENCODE_CASES)('encodes, decodes, and verifies a token for $name', ({
+    ids,
+  }) => {
+    const token = createResumeToken({ ids, expiresAt: EXPIRES_AT }, SECRET)
+    const decodedToken = decodeResumeToken(encodeResumeToken(token))
+
+    expect(decodedToken).not.toBeNull()
+
+    if (!decodedToken) {
+      return
+    }
+
+    expect(verifyResumeToken(decodedToken, SECRET, CREATED_AT)).toEqual({
+      ok: true,
+      ids,
+    })
+  })
+
+  it('rejects an encoded token without a separator', () => {
+    expect(decodeResumeToken('invalid')).toBeNull()
+  })
+
+  it('rejects an encoded token with an invalid base64url payload', () => {
+    expect(decodeResumeToken('invalid+payload.signature')).toBeNull()
+  })
+
+  it('rejects an encoded token whose decoded payload has no separator', () => {
+    const payload = Buffer.from('invalid').toString('base64url')
+
+    expect(decodeResumeToken(`${payload}.signature`)).toBeNull()
+  })
+
+  it('fails verification when an encoded token payload is tampered with', () => {
+    const token = createResumeToken(
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+    const encodedToken = encodeResumeToken(token)
+    const separatorIndex = encodedToken.indexOf('.')
+    const tamperedPayload = Buffer.from(
+      `shokumu-keirekisho-pdf:${token.exp}`
+    ).toString('base64url')
+    const decodedToken = decodeResumeToken(
+      `${tamperedPayload}${encodedToken.slice(separatorIndex)}`
+    )
+
+    expect(decodedToken).not.toBeNull()
+
+    if (!decodedToken) {
+      return
+    }
+
+    expect(verifyResumeToken(decodedToken, SECRET, CREATED_AT)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    })
+  })
+
+  it('fails verification when an encoded token signature is tampered with', () => {
+    const token = createResumeToken(
+      { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },
+      SECRET
+    )
+    const encodedToken = encodeResumeToken(token)
+    const separatorIndex = encodedToken.indexOf('.')
+    const decodedToken = decodeResumeToken(
+      `${encodedToken.slice(0, separatorIndex + 1)}tampered`
+    )
+
+    expect(decodedToken).not.toBeNull()
+
+    if (!decodedToken) {
+      return
+    }
+
+    expect(verifyResumeToken(decodedToken, SECRET, CREATED_AT)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    })
+  })
+
   it('creates and verifies a token for one file', () => {
     const token = createResumeToken(
       { ids: ['rirekisho-pdf'], expiresAt: EXPIRES_AT },

--- a/apps/web/lib/resume/token.ts
+++ b/apps/web/lib/resume/token.ts
@@ -61,6 +61,56 @@ export function createResumeToken(
   return { ids, exp, sig }
 }
 
+export function encodeResumeToken(token: ResumeToken): string {
+  const payload = `${token.ids.join(',')}:${token.exp}`
+  const encodedPayload = Buffer.from(payload).toString('base64url')
+
+  return `${encodedPayload}.${token.sig}`
+}
+
+export function decodeResumeToken(
+  value: string
+): { ids: string[]; exp: string; sig: string } | null {
+  const parts = value.split('.')
+
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const [encodedPayload, sig] = parts
+
+  if (
+    !encodedPayload ||
+    sig === undefined ||
+    !/^[A-Za-z0-9_-]+$/.test(encodedPayload)
+  ) {
+    return null
+  }
+
+  try {
+    const payloadBuffer = Buffer.from(encodedPayload, 'base64url')
+
+    if (payloadBuffer.toString('base64url') !== encodedPayload) {
+      return null
+    }
+
+    const payload = payloadBuffer.toString()
+    const separatorIndex = payload.lastIndexOf(':')
+
+    if (separatorIndex === -1) {
+      return null
+    }
+
+    return {
+      ids: payload.slice(0, separatorIndex).split(','),
+      exp: payload.slice(separatorIndex + 1),
+      sig,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function verifyResumeToken(
   token: { ids: string[]; exp: string; sig: string },
   secret: string,


### PR DESCRIPTION
## 概要

resume のダウンロード URL がファイル ID(書類名)をクエリに露出していて冗長だったのを、不透明トークン1パラメータ形式に変更。

```
旧: /api/resume/download?ids=rirekisho-pdf,shokumu-keirekisho-pdf&exp=1754380800&sig=...
新: /api/resume/download?t=<base64url(ids:exp)>.<sig>
```

## 変更内容

- `lib/resume/token.ts`: `encodeResumeToken` / `decodeResumeToken` を追加(既存の署名・検証ロジックは無変更)
- `app/api/resume/download/route.ts`: `t` パラメータを優先処理。無ければ旧形式 `ids`/`exp`/`sig` にフォールバック(admin 発行済みの長期有効 URL を維持)
- `requestDownloadUrl` / `issueDownloadUrl`: `?t=` 形式で URL を発行
- `token.test.ts`: encode/decode 往復・payload 改ざん・sig 改ざん・不正 base64url のテストを追加(既存テストは無変更 = 旧形式互換の証明)

## テスト

- `pnpm vitest run lib/resume/token.test.ts` → 19 passed
- `pnpm exec tsc --noEmit` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)